### PR TITLE
fix: Fixing Windows target to run (and update to latest sdk)

### DIFF
--- a/samples/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Properties/launchSettings.json
+++ b/samples/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Resizetizer.Windows": {
+      "commandName": "MsixPackage"
+    }
+  }
+}

--- a/samples/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Uno.Resizetizer.Sample.Windows.csproj
+++ b/samples/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Uno.Resizetizer.Sample.Windows.csproj
@@ -23,8 +23,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221116.1" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 
@@ -48,8 +48,8 @@
 		the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
 		must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 		-->
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
 	</ItemGroup>
 	
 	<Import Project="..\Uno.Resizetizer.Sample.Shared\Uno.Resizetizer.Sample.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Windows target fails to run

## What is the new behavior?

Windows target is updated to latest SDK and runs

