### PR TITLE
fix: Missing images on wasm/ios/android

### DIFF
--- a/samples/NewTemplate/Resizetizer.Extensions.Sample/Resizetizer.Extensions.Sample.csproj
+++ b/samples/NewTemplate/Resizetizer.Extensions.Sample/Resizetizer.Extensions.Sample.csproj
@@ -48,7 +48,6 @@
 		<Content Include="Images\dotnet_bot_img.png">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<UnoImage Include="Images\dotnet_bot.svg" />
 		<Content Include="..\dotnet_bot_link.png">
 			<Link>MyImages\dotnet_bot_link.png</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -456,7 +456,7 @@
 
 		<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">
 			<Content Include="@(_ResizetizerCollectedImages)"
-					  CopyToOutputDirectory="Always"
+					  CopyToOutputDirectory="PreserveNewest"
 					 Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)"
 					 TargetPath="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)">
 			</Content>


### PR DESCRIPTION
GitHub Issue (If applicable): #53 


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

ms-appx://Folder/Image.png can't be used in class library to reference image
(WASM/iOS/Android)
(see comment https://github.com/unoplatform/uno.resizetizer/issues/53#issuecomment-1420321998)

## What is the new behavior?

ms-appx://Folder/Image.png works
(WASM/Android)

At this stage iOS still has issues with linked files (see https://github.com/unoplatform/uno/issues/11204) which affects both images linked directly in the class library as well as those generated by uno.resizetizer. The only way of referencing linked (and resizetizer) images is using ms-appx///Folder/Image.png