### PR TITLE
feat: added Error message when  both values are the same

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -358,6 +358,14 @@
             Text="More than one 'UnoSplashScreen' is defined; only the first will be used."
         />
 
+		<Error 
+			Condition="'@(UnoSplashScreen)' == '@(UnoIcon)'"
+			Text= "The value of UnoSplashScreen and UnoIcon cannot be the same." />
+			
+		<Error 
+			Condition="'@(UnoSplashScreen)' == '%(UnoIcon.ForegroundFile)'"
+			Text= "The value of UnoSplashScreen and UnoIcon cannot be the same." />
+
 		 <!--Wasm--> 
 
 		 <ItemGroup Condition="$(_ResizetizerIsWasmApp) == 'True' Or $(_ResizetizerIsSkiaApp) == 'True' ">


### PR DESCRIPTION
GitHub Issue (If applicable): #98

Right now, you can't use the same asset as UnoIcon and UnoSplashScreen. So, we added this verification step and an error message.