### PR TITLE
Fixed appxmanifest name on skia targets

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -642,9 +642,17 @@
 		<ItemGroup Condition="'@(_SkiaManifest)' != '' ">
 			<AppxManifest Remove="@(AppxManifest)" />
 			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
+			
+			<!--If there's no LogicalName, we use the default name-->
 			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
 			                  Link="%(_SkiaManifest.Link)"
-			                  LogicalName="$(AssemblyName).Package.appxmanifest"/>
+			                  LogicalName="Package.appxmanifest"
+							  Condition="%(_SkiaManifest.LogicalName) == '' "/>
+
+			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
+			                  Link="%(_SkiaManifest.Link)"
+			                  LogicalName="%(_SkiaManifest.LogicalName)"
+							  Condition="%(_SkiaManifest.LogicalName) != '' "/>
 
 		</ItemGroup>
 		<ItemGroup Condition="'@(_UnoAppxManifest)' != ''">

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -644,7 +644,7 @@
 			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
 			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
 			                  Link="%(_SkiaManifest.Link)"
-			                  LogicalName="%(_SkiaManifest.LogicalName)"/>
+			                  LogicalName="$(AssemblyName).Package.appxmanifest"/>
 
 		</ItemGroup>
 		<ItemGroup Condition="'@(_UnoAppxManifest)' != ''">


### PR DESCRIPTION
Fixes: #122 


Now if the user doesn't specify the `LogicalName` we will use `Package.appxmanifest` as the default value.