### PR TITLE
Make sure the task will not regenerate unchanged assets

### DIFF
--- a/samples/Legacy/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Uno.Resizetizer.Sample.Windows.csproj
+++ b/samples/Legacy/Uno.Resizetizer.Sample/Uno.Resizetizer.Sample.Windows/Uno.Resizetizer.Sample.Windows.csproj
@@ -59,7 +59,7 @@
 	<Target Name="ValidateTransientLocalAssets" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
 		<PropertyGroup>
 			<_ResizetizerManifestPath>$(_UnoIntermediateManifest)Package.appxmanifest</_ResizetizerManifestPath>
-			<_ResizetizerSplashScreenPath>$(_UnoIntermediateSplashScreen)Assets\Images\splash_screenSplashScreen.scale-150.png</_ResizetizerSplashScreenPath>
+			<_ResizetizerSplashScreenPath>$(_UnoIntermediateSplashScreen)splash_screen.scale-150.png</_ResizetizerSplashScreenPath>
 			<_ResizetizerAppIconPath>$(_UnoIntermediateImages)iconapp.ico</_ResizetizerAppIconPath>
 			<_ResizetizerAppIconImagesPath>$(_UnoIntermediateImages)Images\iconappLogo.scale-150.png</_ResizetizerAppIconImagesPath>
 			<_ResizetizerImagesNestedPath>$(_UnoIntermediateImages)MyAssets\Nested\dotnet_bot.scale-300.png</_ResizetizerImagesNestedPath>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -314,24 +314,6 @@
 			<UnoImage Include="@(UnoIcon)" IsAppIcon="True" Link="" />
 		</ItemGroup>
 
-		<!-- Write out item spec and metadata to a file we can use as an inputs for the resize target -->
-		<!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
-		<WriteLinesToFile
-			File="$(_ResizetizerInputsFile)"
-			Lines="@(UnoImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
-			Overwrite="true"
-			WriteOnlyWhenDifferent="true" />
-
-		<WriteLinesToFile
-			File="$(_UnoSplashInputsFile)"
-			Lines="@(UnoSplashScreen->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);ForegroundScale=%(ForegroundScale)')"
-			Overwrite="true"
-			WriteOnlyWhenDifferent="true" />
-
-		<ItemGroup>
-			<FileWrites Include="$(_ResizetizerInputsFile)" />
-			<FileWrites Include="$(_UnoSplashInputsFile)" />
-		</ItemGroup>
 		<ItemGroup>
 			<_SkiaManifest Include="@(EmbeddedResource)"
 							 Condition="%(Extension) == '.appxmanifest'"/>
@@ -339,6 +321,30 @@
 			<EmbeddedResource Remove="@(EmbeddedResource)"
 								Condition="%(Extension) == '.appxmanifest'"/>
 		</ItemGroup>
+	</Target>
+
+	<Target Name="GenerateInfoAboutAssets"
+			AfterTargets="ResizetizeCollectItems"
+			BeforeTargets="ResizetizeImages_v0;ProcessUnoSplashScreens;ProcessUnoAssets">
+			
+			<!-- Write out item spec and metadata to a file we can use as an inputs for the resize target -->
+			<!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
+			<WriteLinesToFile
+				File="$(_ResizetizerInputsFile)"
+				Lines="@(UnoImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
+				Overwrite="true"
+				WriteOnlyWhenDifferent="true" />
+
+			<WriteLinesToFile
+				File="$(_UnoSplashInputsFile)"
+				Lines="@(UnoSplashScreen->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);ForegroundScale=%(ForegroundScale)')"
+				Overwrite="true"
+				WriteOnlyWhenDifferent="true" />
+
+			<ItemGroup>
+				<FileWrites Include="$(_ResizetizerInputsFile)" />
+				<FileWrites Include="$(_UnoSplashInputsFile)" />
+			</ItemGroup>
 	</Target>
 
 	<Target Name="ProcessUnoAssets">

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -125,6 +125,16 @@
 			UnoAssetsGeneration;
 			BuildDist;
 		</ResizetizeAfterTargets>
+		
+		<ResizetizeDependsOnTargets>
+			$(ResizetizeDependsOnTargets);
+			ResizetizeCollectItems;
+			ProcessUnoSplashScreens;
+		</ResizetizeDependsOnTargets>
+		
+		<ResizetizeCollectItemsBeforeTargets>
+			UnoAssetsGeneration;
+		</ResizetizeCollectItemsBeforeTargets>
 	</PropertyGroup>
 
 	<!-- Skia -->
@@ -276,7 +286,7 @@
 
 	<!-- Collect images from referenced projects -->
 	<Target Name="ResizetizeCollectItems"
-		Condition="'$(_ResizetizerIsCompatibleApp)' == 'True' And '$(DisableResizetizer)' != 'true'"
+		Condition="'$(DisableResizetizer)' != 'True'"
 		BeforeTargets="$(ResizetizeCollectItemsBeforeTargets)"
 		AfterTargets="$(ResizetizeCollectItemsAfterTargets)">
 


### PR DESCRIPTION
GitHub Issue (If applicable): #134


This PR makes sure the class library project generates the needed files to check if the images are already created.


## Old behavior

The ResizeCollectItems task didn't run for class lib, and with that, some information wasn't cached.

## Actual behavior

The ResizeCollectItems task runs and now we have the all the files created and used to improve the build time.

Before this, on incremental build:
![image](https://github.com/unoplatform/uno.resizetizer/assets/20712372/c51daf40-0681-452e-a16b-92d2f0c495c2)


After this, on incremental build:
![image](https://github.com/unoplatform/uno.resizetizer/assets/20712372/24d2c34f-6c32-42f6-b081-8662fb474e9b)

