### PR TITLE
Fix Window Icon Extensions

### DIFF
--- a/samples/NewTemplate/Resizetizer.Extensions.Sample.Base/AppHead.xaml.cs
+++ b/samples/NewTemplate/Resizetizer.Extensions.Sample.Base/AppHead.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
+using Uno.Resizetizer;
 
 namespace Resizetizer.Extensions.Sample;
 
@@ -16,6 +17,12 @@ public sealed partial class AppHead : App
 	public AppHead()
 	{
 		this.InitializeComponent();
+	}
+
+	protected override void OnLaunched(LaunchActivatedEventArgs args)
+	{
+		base.OnLaunched(args);
+		_window?.SetWindowIcon();
 	}
 
 	/// <summary>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -682,7 +682,6 @@
 	</Target>
 
 	<Target Name="_GenerateWindowUnoIconExtension"
-			BeforeTargets="Build;CoreCompile"
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
@@ -692,9 +691,15 @@
 				TaskParameter="GeneratedClass"/>
 			<Output ItemName="FilesWrite"
 				TaskParameter="GeneratedClass"/>
-			<Output ItemName="Compile"
-				TaskParameter="GeneratedClass"/>
 		</WindowIconGeneratorTask_v0>
+	</Target>
+
+	<Target Name="_AddResizetizerWindowIconExtensions"
+			AfterTargets="_GenerateWindowUnoIconExtension"
+			BeforeTargets="Build;CoreCompile;XamlPreCompile">
+		<ItemGroup Condition="Exists('$(_ResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs')">
+			<Compile Include="$(_ResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs" />
+		</ItemGroup>
 	</Target>
 
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -682,6 +682,8 @@
 	</Target>
 
 	<Target Name="_GenerateWindowUnoIconExtension"
+			Condition="'$(_ResizetizerIsCompatibleApp)' == 'True'"
+			BeforeTargets="Build;CoreCompile;XamlPreCompile"
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
@@ -695,10 +697,11 @@
 	</Target>
 
 	<Target Name="_AddResizetizerWindowIconExtensions"
+			Condition="'$(_ResizetizerIsCompatibleApp)' == 'True'"
 			AfterTargets="_GenerateWindowUnoIconExtension"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile">
-		<ItemGroup Condition="Exists('$(_ResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs')">
-			<Compile Include="$(_ResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs" />
+		<ItemGroup Condition="Exists('@(_WindowIconExtension->FullPath())')">
+			<Compile Include="@(_WindowIconExtension)" />
 		</ItemGroup>
 	</Target>
 

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -334,10 +334,10 @@
 		</ItemGroup>
 		<ItemGroup>
 			<_SkiaManifest Include="@(EmbeddedResource)"
-						   Condition="%(Extension) == '.appxmanifest'"/>
+							 Condition="%(Extension) == '.appxmanifest'"/>
 
 			<EmbeddedResource Remove="@(EmbeddedResource)"
-							  Condition="%(Extension) == '.appxmanifest'"/>
+								Condition="%(Extension) == '.appxmanifest'"/>
 		</ItemGroup>
 	</Target>
 
@@ -401,7 +401,7 @@
 		<ItemGroup Condition="$(_ResizetizerIsWasmApp) == 'True' And $(UserAppManifest) != ''">
 			<EmbeddedResource Remove="$(UserAppManifest)" />
 			<EmbeddedResource Include="$(_UnoIntermediateAppManifestWasm)"
-							  Link="$(UserAppManifest)"/>
+								Link="$(UserAppManifest)"/>
 		</ItemGroup>
 
 		<!-- Android -->
@@ -653,14 +653,14 @@
 			
 			<!--If there's no LogicalName, we use the default name-->
 			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-							  Link="%(_SkiaManifest.Link)"
-							  LogicalName="Package.appxmanifest"
-							  Condition="%(_SkiaManifest.LogicalName) == '' "/>
+								Link="%(_SkiaManifest.Link)"
+								LogicalName="Package.appxmanifest"
+								Condition="%(_SkiaManifest.LogicalName) == '' "/>
 
 			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-							  Link="%(_SkiaManifest.Link)"
-							  LogicalName="%(_SkiaManifest.LogicalName)"
-							  Condition="%(_SkiaManifest.LogicalName) != '' "/>
+								Link="%(_SkiaManifest.Link)"
+								LogicalName="%(_SkiaManifest.LogicalName)"
+								Condition="%(_SkiaManifest.LogicalName) != '' "/>
 
 		</ItemGroup>
 		<ItemGroup Condition="'@(_UnoAppxManifest)' != ''">


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #129

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Windows head does not have code generated for the Window Icon Extensions

## What is the new behavior?

The target now ensures it runs before XamlPreCompile and it exists early enough for the compilation to succeed.