### PR TITLE
Refactored ResizeImage task

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -510,7 +510,7 @@
 	</Target>
 
 	<Target Name="ResizetizeImages_v0"
-		Inputs="$(_ResizetizerInputsFile);@(UnoImage)"
+		Inputs="$(_ResizetizerInputsFile);@(UnoImage);$(_WasmPwaManifestPath)"
 		Outputs="$(_ResizetizerStampFile);@(_ResizetizerCollectedImages);@(_ResizetizerCollectedAppIcons)"
 		AfterTargets="$(ResizetizeAfterTargets)"
 		Condition="'$(DesignTimeBuild)' != 'true'"
@@ -538,18 +538,21 @@
 			<Output PropertyName="ResizetizerPwaManifest"
 					TaskParameter="PwaGeneratedManifestPath"/>
 		</ResizetizeImages_v0>
-
-		<PropertyGroup>
-			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
-		</PropertyGroup>
 		
 		<ItemGroup>
-				<!-- Get Images that were generated -->
-				<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
-				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
-				<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+			<!-- Get Images that were generated -->
+			<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
+			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
+			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
+			<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+			<!-- If the PWA manifest is empty we can try to find it on the disk -->
+			<_ResizetizerPwaManifestItemGroup Condition="'$(ResizetizerPwaManifest)' ==''" Include="$(_UnoIntermediateAppIcon)**\*.json"/>
 		</ItemGroup>
+		
+		<PropertyGroup>
+			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
+			<ResizetizerPwaManifest Condition="'$(ResizetizerPwaManifest)' ==''">%(_ResizetizerPwaManifestItemGroup.FullPath)</ResizetizerPwaManifest>
+		</PropertyGroup>
 
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!-- Touch/create our stamp file for outputs -->

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -511,7 +511,7 @@
 
 	<Target Name="ResizetizeImages_v0"
 		Inputs="$(_ResizetizerInputsFile);@(UnoImage)"
-		Outputs="$(_ResizetizerStampFile)"
+		Outputs="$(_ResizetizerStampFile);@(_ResizetizerCollectedImages);@(_ResizetizerCollectedAppIcons)"
 		AfterTargets="$(ResizetizeAfterTargets)"
 		Condition="'$(DesignTimeBuild)' != 'true'"
 		BeforeTargets="$(ResizetizeBeforeTargets)"
@@ -539,6 +539,18 @@
 					TaskParameter="PwaGeneratedManifestPath"/>
 		</ResizetizeImages_v0>
 
+		<PropertyGroup>
+			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
+		</PropertyGroup>
+		
+		<ItemGroup>
+				<!-- Get Images that were generated -->
+				<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
+				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
+				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
+				<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+		</ItemGroup>
+
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!-- Touch/create our stamp file for outputs -->
 		<Touch Files="$(_ResizetizerStampFile)" AlwaysCreate="True" />
@@ -554,19 +566,6 @@
 		AfterTargets="ResizetizeImages_v0"
 		DependsOnTargets="ResizetizeImages_v0"
 		Condition="'$(DesignTimeBuild)' != 'true'">
-
-		<PropertyGroup>
-			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
-		</PropertyGroup>
-		
-		<ItemGroup>
-				<!-- Get Images that were generated -->
-				<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
-				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
-				<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
-			</ItemGroup>
-
 
 			<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">
 				<Content Include="@(_ResizetizerCollectedImages)"

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -334,7 +334,7 @@
 		</ItemGroup>
 		<ItemGroup>
 			<_SkiaManifest Include="@(EmbeddedResource)"
-							 Condition="%(Extension) == '.appxmanifest'"/>
+						   Condition="%(Extension) == '.appxmanifest'"/>
 
 			<EmbeddedResource Remove="@(EmbeddedResource)"
 								Condition="%(Extension) == '.appxmanifest'"/>
@@ -545,12 +545,17 @@
 			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
 			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
 			<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+			
 			<!-- If the PWA manifest is empty we can try to find it on the disk -->
 			<_ResizetizerPwaManifestItemGroup Condition="'$(ResizetizerPwaManifest)' ==''" Include="$(_UnoIntermediateAppIcon)**\*.json"/>
+			<!-- If the AppIcon property is empty we can try to find it on the disk -->
+			<_AppIconItemGroup Condition="'$(AppIconPath)' == ''" Include="$(_ResizetizerIntermediateOutputRoot)**\*.ico"/>
 		</ItemGroup>
 		
 		<PropertyGroup>
+			<AppIconPath Condition="'$(AppIconPath)' == ''">%(_AppIconItemGroup.FullPath)</AppIconPath>
 			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
+
 			<ResizetizerPwaManifest Condition="'$(ResizetizerPwaManifest)' ==''">%(_ResizetizerPwaManifestItemGroup.FullPath)</ResizetizerPwaManifest>
 		</PropertyGroup>
 
@@ -569,7 +574,7 @@
 		AfterTargets="ResizetizeImages_v0"
 		DependsOnTargets="ResizetizeImages_v0"
 		Condition="'$(DesignTimeBuild)' != 'true'">
-
+		
 			<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">
 				<Content Include="@(_ResizetizerCollectedImages)"
 						Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)"

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -510,7 +510,7 @@
 	</Target>
 
 	<Target Name="ResizetizeImages_v0"
-		Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_ResizetizerInputsFile);@(UnoImage)"
+		Inputs="$(_ResizetizerInputsFile);@(UnoImage)"
 		Outputs="$(_ResizetizerStampFile)"
 		AfterTargets="$(ResizetizeAfterTargets)"
 		Condition="'$(DesignTimeBuild)' != 'true'"
@@ -539,98 +539,6 @@
 					TaskParameter="PwaGeneratedManifestPath"/>
 		</ResizetizeImages_v0>
 
-		<ItemGroup>
-			<!-- Get Images that were generated -->
-			<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
-			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
-			<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
-		</ItemGroup>
-
-
-		<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">
-			<Content Include="@(_ResizetizerCollectedImages)"
-					 Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)"
-					 TargetPath="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)">
-			</Content>
-
-			<FileWrites Include="@(_ResizetizerCollectedImages)" />
-		</ItemGroup>
-
-		<!--
-		Disables "XA0101 build action is not supported" as Uno handles Content items explicitly
-		https://github.com/xamarin/xamarin-android/blob/311b41e864a0162895d079477cb9398fbec5ca6e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L833
-		-->
-		<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
-			<Content Update="@(_ResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
-		</ItemGroup>
-
-		<!-- Wasm -->
-		<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' == 'True'">
-			<Content Include="@(_ResizetizerCollectedImages->FullPath())"
-					 Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)" >
-			</Content>
-
-			<Content Include="@(_ResizetizerCollectedAppIcons->FullPath())"
-					 Condition="'%(Extension)' != '.ico'"
-					 Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)"/>
-
-			<Content Include="@(_ResizetizerCollectedAppIcons->FullPath())"
-					 Condition="'%(Extension)' == '.ico'"
-					 UnoDeploy="Root"
-					 Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)"/>
-
-			<FileWrites Include="@(_ResizetizerCollectedImages)" />
-		</ItemGroup>
-
-		<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' == 'True' And '$(ResizetizerPwaManifest)' != ''">
-			<Content Remove="$(WasmPWAManifestFile)" />
-			<Content Include="$(ResizetizerPwaManifest)"
-					 CopyToOutputDirectory="PreserveNewest"
-					 ExcludeFromSingleFile ="True"
-					 CopyToPublishDirectory ="PreserveNewest"
-					 Link="$(WasmPWAManifestFile)" />
-		</ItemGroup>
-
-		<!-- Android -->
-		<ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
-			<AndroidResource Include="@(_ResizetizerCollectedAppIcons)"
-					 Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)" >
-			</AndroidResource>
-		</ItemGroup>
-
-
-		<ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">
-			<_ResizetizerCollectedBundleResourceImages Include="@(_ResizetizerCollectedImages->'%(FullPath)')">
-				<LogicalName>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</LogicalName>
-				<TargetPath>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</TargetPath>
-			</_ResizetizerCollectedBundleResourceImages>
-
-			<ImageAsset
-				Include="@(_ResizetizerCollectedBundleResourceImages)"
-				Condition="'@(_ResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_ResizetizerCollectedBundleResourceImages.Identity)' != ''">
-				<LogicalName>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</LogicalName>
-				<TargetPath>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</TargetPath>
-				<Link>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</Link>
-			</ImageAsset>
-		</ItemGroup>
-
-		<!-- iOS Only -->
-		<!-- If on Windows, using build host, copy the files over to build server host too -->
-		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-			<_UnoImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
-				<TargetPath>%(Identity)</TargetPath>
-			</_UnoImagesToCopyToBuildServer>
-		</ItemGroup>
-		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
-			SessionId="$(BuildSessionId)"
-			Files="@(_UnoImagesToCopyToBuildServer)" />
-
-		<PropertyGroup>
-			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
-		</PropertyGroup>
-
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!-- Touch/create our stamp file for outputs -->
 		<Touch Files="$(_ResizetizerStampFile)" AlwaysCreate="True" />
@@ -639,6 +547,106 @@
 		<ItemGroup>
 			<FileWrites Include="$(_ResizetizerStampFile)" />
 		</ItemGroup>
+	</Target>
+	
+	<Target
+		Name="ProcessResizedImages_v0"
+		AfterTargets="ResizetizeImages_v0"
+		DependsOnTargets="ResizetizeImages_v0"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+
+		<PropertyGroup>
+			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
+		</PropertyGroup>
+		
+		<ItemGroup>
+				<!-- Get Images that were generated -->
+				<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
+				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
+				<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
+				<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+			</ItemGroup>
+
+
+			<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">
+				<Content Include="@(_ResizetizerCollectedImages)"
+						Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)"
+						TargetPath="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)">
+				</Content>
+
+				<FileWrites Include="@(_ResizetizerCollectedImages)" />
+			</ItemGroup>
+
+			<!--
+			Disables "XA0101 build action is not supported" as Uno handles Content items explicitly
+			https://github.com/xamarin/xamarin-android/blob/311b41e864a0162895d079477cb9398fbec5ca6e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L833
+			-->
+			<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
+				<Content Update="@(_ResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
+			</ItemGroup>
+
+			<!-- Wasm -->
+			<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' == 'True'">
+				<Content Include="@(_ResizetizerCollectedImages->FullPath())"
+						Link="%(_ResizetizerCollectedImages.RecursiveDir)%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)" >
+				</Content>
+
+				<Content Include="@(_ResizetizerCollectedAppIcons->FullPath())"
+						Condition="'%(Extension)' != '.ico'"
+						Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)"/>
+
+				<Content Include="@(_ResizetizerCollectedAppIcons->FullPath())"
+						Condition="'%(Extension)' == '.ico'"
+						UnoDeploy="Root"
+						Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)"/>
+
+				<FileWrites Include="@(_ResizetizerCollectedImages)" />
+			</ItemGroup>
+
+			<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' == 'True' And '$(ResizetizerPwaManifest)' != ''">
+				<Content Remove="$(WasmPWAManifestFile)" />
+				<Content Include="$(ResizetizerPwaManifest)"
+						CopyToOutputDirectory="PreserveNewest"
+						ExcludeFromSingleFile ="True"
+						CopyToPublishDirectory ="PreserveNewest"
+						Link="$(WasmPWAManifestFile)" />
+			</ItemGroup>
+
+			<!-- Android -->
+			<ItemGroup Condition="'$(_ResizetizerIsAndroidApp)' == 'True'">
+				<AndroidResource Include="@(_ResizetizerCollectedAppIcons)"
+						Link="%(_ResizetizerCollectedAppIcons.RecursiveDir)%(_ResizetizerCollectedAppIcons.Filename)%(_ResizetizerCollectedAppIcons.Extension)" >
+				</AndroidResource>
+			</ItemGroup>
+
+
+			<ItemGroup Condition="'$(_ResizetizerIsiOSApp)' == 'True'">
+				<_ResizetizerCollectedBundleResourceImages Include="@(_ResizetizerCollectedImages->'%(FullPath)')">
+					<LogicalName>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</LogicalName>
+					<TargetPath>%(_ResizetizerCollectedImages.Filename)%(_ResizetizerCollectedImages.Extension)</TargetPath>
+				</_ResizetizerCollectedBundleResourceImages>
+
+				<ImageAsset
+					Include="@(_ResizetizerCollectedBundleResourceImages)"
+					Condition="'@(_ResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_ResizetizerCollectedBundleResourceImages.Identity)' != ''">
+					<LogicalName>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</LogicalName>
+					<TargetPath>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</TargetPath>
+					<Link>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_ResizetizerCollectedBundleResourceImages.Identity)))))\%(_ResizetizerCollectedBundleResourceImages.Filename)%(_ResizetizerCollectedBundleResourceImages.Extension)</Link>
+				</ImageAsset>
+			</ItemGroup>
+
+			<!-- iOS Only -->
+			<!-- If on Windows, using build host, copy the files over to build server host too -->
+			<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+				<_UnoImagesToCopyToBuildServer Include="@(_ResizetizerCollectedBundleResourceImages)">
+					<TargetPath>%(Identity)</TargetPath>
+				</_UnoImagesToCopyToBuildServer>
+			</ItemGroup>
+			<CopyFilesToBuildServer
+				Condition="'$(BuildSessionId)' != '' And '$(_ResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
+				SessionId="$(BuildSessionId)"
+				Files="@(_UnoImagesToCopyToBuildServer)" />
+
 	</Target>
 
 	<!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly depends


### PR DESCRIPTION
GitHub Issue (If applicable): #134 

## What is the current behavior?

Actually, the generated values aren't cached, so if the user rebuilds the shared project and builds (or presses F5) it will not re-evaluate the values on the head project causing some assets to be missed, like pwaManifest, app icon, etc.


## What is the new behavior?

The `ResizetizeImages_v0` was divided in two, the one that generates the assets and populates all properties that we need to process the generated assets and the `ProcessResizedImages_v0` target that's responsible to consume and process all the generated assets. With this, we can better cache the values avoiding them being missed during the build/rebuild process.


## Other information

This is a piece of a large ticket, so this change will be merged on `pj/build-task-update` branch and in the future that will be merged on `main`
