### PR TITLE
Fixed incremental builds

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -515,7 +515,19 @@
 			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
 			<_ResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
 			<_ResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
+			
+			<!-- If the PWA manifest is empty we can try to find it on the disk -->
+			<_ResizetizerPwaManifestItemGroup Condition="'$(ResizetizerPwaManifest)' ==''" Include="$(_UnoIntermediateAppIcon)**\*.json"/>
+			<!-- If the AppIcon property is empty we can try to find it on the disk -->
+			<_AppIconItemGroup Condition="'$(AppIconPath)' == ''" Include="$(_ResizetizerIntermediateOutputRoot)**\*.ico"/>
 		</ItemGroup>
+
+		<PropertyGroup>
+			<!-- If the PWA manifest is empty we can try to find it on the disk -->
+			<ResizetizerPwaManifest Condition="'$(ResizetizerPwaManifest)' ==''">%(_ResizetizerPwaManifestItemGroup.FullPath)</ResizetizerPwaManifest>
+			<!-- If the AppIcon property is empty we can try to find it on the disk -->
+			<AppIconPath Condition="'$(AppIconPath)' == ''">%(_AppIconItemGroup.Identity)</AppIconPath>
+		</PropertyGroup>
 
 
 		<ItemGroup Condition="'$(_ResizetizerIsWasmApp)' != 'True'">


### PR DESCRIPTION
This PR is a port of a fix implemented on #134 ticket.

### Current Behavior

On the new template, if you rebuild the class lib project and press F5 or just build the head project, the `Pwa manifest` will not be updated nor the `ApplicationIcon`(for Skia targets). The reason is that the `ResizetizerImages_v0` task will not be executed since the Inputs/Outputs will be evaluated as the same as the previous build.


### PR Behavior

This PR adds a step to lookup the generated files and find the `Pwa manifest` and `Application icon` and include them in the build process.