### PR TITLE
Renamed another target name

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -625,7 +625,7 @@
 
 	<!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly depends
 		 on "_ValidatePresenceOfAppxManifestItems" and we need to get in before then. -->
-	<Target Name="_ValidatePresenceOfAppxManifestItemsBeforeTarget"
+	<Target Name="_UnoValidatePresenceOfAppxManifestItemsBeforeTarget"
 			BeforeTargets="_ValidatePresenceOfAppxManifestItems"
 			DependsOnTargets="UnoGeneratePackageAppxManifest"
 			Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />


### PR DESCRIPTION
This is to avoid another naming colision