### PR TITLE
Refactoring the MSBuild tasks

### DIFF
--- a/samples/NewTemplate/Resizetizer.Extensions.Sample.sln
+++ b/samples/NewTemplate/Resizetizer.Extensions.Sample.sln
@@ -27,6 +27,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		..\..\src\.nuspec\Uno.Resizetizer.targets = ..\..\src\.nuspec\Uno.Resizetizer.targets
+		..\..\src\.nuspec\Uno.Resizetizer.android.targets = ..\..\src\.nuspec\Uno.Resizetizer.android.targets
+		..\..\src\.nuspec\Uno.Resizetizer.apple.targets = ..\..\src\.nuspec\Uno.Resizetizer.apple.targets
+		..\..\src\.nuspec\Uno.Resizetizer.wasm.targets = ..\..\src\.nuspec\Uno.Resizetizer.wasm.targets
+		..\..\src\.nuspec\Uno.Resizetizer.windows.skia.targets = ..\..\src\.nuspec\Uno.Resizetizer.windows.skia.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Resizetizer", "..\..\src\Resizetizer\src\Resizetizer.csproj", "{6D3BC015-4BF9-44FA-B3B9-9B44EE13EDA8}"

--- a/src/.nuspec/Uno.Resizetizer.android.targets
+++ b/src/.nuspec/Uno.Resizetizer.android.targets
@@ -1,0 +1,41 @@
+<Project>
+    <Target
+        Name="GenerateUnoSplashAndroid"
+        AfterTargets="GenerateUnoSplashScreens"
+        DependsOnTargets="GenerateUnoSplashScreens"
+        Condition="'$(DesignTimeBuild)' != 'True'">
+    <!-- Android -->
+        <GenerateSplashAndroidResources_v0
+            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+            UnoSplashScreen="@(UnoSplashScreen)"
+        />
+    </Target>
+
+    <Target Name="ProcessUnoSplashScreens"
+        AfterTargets="GenerateUnoSplashAndroid"
+        DependsOnTargets="GenerateUnoSplashAndroid"
+        Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+        
+        <!-- Android -->
+        <ItemGroup>
+			<LibraryResourceDirectories Condition="Exists('$(_UnoIntermediateSplashScreen)')" Include="$(_UnoIntermediateSplashScreen)">
+				<StampFile>$(_UnoResizetizerStampFile)</StampFile>
+			</LibraryResourceDirectories>
+			<FileWrites Include="$(_UnoIntermediateSplashScreen)**\*" />
+		</ItemGroup>
+    </Target>
+
+    <Target
+        Name="ProcessResizedImagesAndroid_v0"
+        AfterTargets="ProcessResizedImages_v0"
+        DependsOnTargets="ProcessResizedImages_v0"
+        Condition="'$(DesignTimeBuild)' != 'true'">
+        
+        <!-- Android -->
+        <ItemGroup>
+			<AndroidResource Include="@(_UnoResizetizerCollectedAppIcons)"
+					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)" >
+			</AndroidResource>
+		</ItemGroup>
+    </Target>
+</Project>

--- a/src/.nuspec/Uno.Resizetizer.android.targets
+++ b/src/.nuspec/Uno.Resizetizer.android.targets
@@ -1,41 +1,41 @@
 <Project>
-    <Target
-        Name="GenerateUnoSplashAndroid"
-        AfterTargets="GenerateUnoSplashScreens"
-        DependsOnTargets="GenerateUnoSplashScreens"
-        Condition="'$(DesignTimeBuild)' != 'True'">
-    <!-- Android -->
-        <GenerateSplashAndroidResources_v0
-            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-            UnoSplashScreen="@(UnoSplashScreen)"
-        />
-    </Target>
+	<Target
+			Name="GenerateUnoSplashAndroid"
+			AfterTargets="GenerateUnoSplashScreens"
+			DependsOnTargets="GenerateUnoSplashScreens"
+			Condition="'$(DesignTimeBuild)' != 'True'">
+		<!-- Android -->
+		<GenerateSplashAndroidResources_v0
+				IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+				UnoSplashScreen="@(UnoSplashScreen)"
+		/>
+	</Target>
 
-    <Target Name="ProcessUnoSplashScreens"
-        AfterTargets="GenerateUnoSplashAndroid"
-        DependsOnTargets="GenerateUnoSplashAndroid"
-        Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
-        
-        <!-- Android -->
-        <ItemGroup>
+	<Target Name="ProcessUnoSplashScreens"
+			AfterTargets="GenerateUnoSplashAndroid"
+			DependsOnTargets="GenerateUnoSplashAndroid"
+			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+
+		<!-- Android -->
+		<ItemGroup>
 			<LibraryResourceDirectories Condition="Exists('$(_UnoIntermediateSplashScreen)')" Include="$(_UnoIntermediateSplashScreen)">
 				<StampFile>$(_UnoResizetizerStampFile)</StampFile>
 			</LibraryResourceDirectories>
-			<FileWrites Include="$(_UnoIntermediateSplashScreen)**\*" />
+			<FileWrites Include="$(_UnoIntermediateSplashScreen)**\*"/>
 		</ItemGroup>
-    </Target>
+	</Target>
 
-    <Target
-        Name="ProcessResizedImagesAndroid_v0"
-        AfterTargets="ProcessResizedImages_v0"
-        DependsOnTargets="ProcessResizedImages_v0"
-        Condition="'$(DesignTimeBuild)' != 'true'">
-        
-        <!-- Android -->
-        <ItemGroup>
+	<Target
+			Name="ProcessResizedImagesAndroid_v0"
+			AfterTargets="ProcessResizedImages_v0"
+			DependsOnTargets="ProcessResizedImages_v0"
+			Condition="'$(DesignTimeBuild)' != 'true'">
+
+		<!-- Android -->
+		<ItemGroup>
 			<AndroidResource Include="@(_UnoResizetizerCollectedAppIcons)"
-					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)" >
+							 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)">
 			</AndroidResource>
 		</ItemGroup>
-    </Target>
+	</Target>
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.apple.targets
+++ b/src/.nuspec/Uno.Resizetizer.apple.targets
@@ -6,11 +6,11 @@
 		Condition="'$(DesignTimeBuild)' != 'True'">
         <!-- iOS, but not Catalyst -->
 		<GenerateSplashStoryboard_v0
-            Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'"
+            Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'"
             OutputFile="$(_UnoIntermediateStoryboard)"
             UnoSplashScreen="@(UnoSplashScreen)"
         />
-        <PropertyGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+        <PropertyGroup Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'">
             <_UnoIntermediateSplashScreenFile>$(_UnoIntermediateStoryboard)</_UnoIntermediateSplashScreenFile>
         </PropertyGroup>
         <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
@@ -32,19 +32,19 @@
         Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
 
         <!-- iOS, but not Catalyst -->
-        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' ">
+        <ItemGroup>
 			<_UnoSplashPListFiles Include="$(_UnoIntermediateSplashScreen)UnoInfo.plist" Condition="Exists('$(_UnoIntermediateSplashScreen)UnoInfo.plist')" />
 			<PartialAppManifest Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
 			<FileWrites Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
 		</ItemGroup>
 
-		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'">
 			<_UnoAssetsToCopyToBuildServer Include="@(_UnoSplashPListFiles)">
 				<TargetPath>%(Identity)</TargetPath>
 			</_UnoAssetsToCopyToBuildServer>
 		</ItemGroup>
 		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
+			Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
 			SessionId="$(BuildSessionId)"
 			Files="@(_UnoAssetsToCopyToBuildServer)" />
     </Target>
@@ -54,7 +54,7 @@
 		AfterTargets="ProcessResizedImages_v0"
 		DependsOnTargets="ProcessResizedImages_v0"
 		Condition="'$(DesignTimeBuild)' != 'true'">
-        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'">
+        <ItemGroup>
 			<_UnoResizetizerCollectedBundleResourceImages Include="@(_UnoResizetizerCollectedImages->'%(FullPath)')">
 				<LogicalName>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</LogicalName>
 				<TargetPath>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</TargetPath>
@@ -71,13 +71,13 @@
 
 		<!-- iOS Only -->
 		<!-- If on Windows, using build host, copy the files over to build server host too -->
-		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'">
 			<_UnoImagesToCopyToBuildServer Include="@(_UnoResizetizerCollectedBundleResourceImages)">
 				<TargetPath>%(Identity)</TargetPath>
 			</_UnoImagesToCopyToBuildServer>
 		</ItemGroup>
 		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
+			Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
 			SessionId="$(BuildSessionId)"
 			Files="@(_UnoImagesToCopyToBuildServer)" />
     </Target>

--- a/src/.nuspec/Uno.Resizetizer.apple.targets
+++ b/src/.nuspec/Uno.Resizetizer.apple.targets
@@ -1,0 +1,84 @@
+<Project>
+    <Target
+        Name="GenerateUnoSplashApple"
+		AfterTargets="GenerateUnoSplashScreens"
+		DependsOnTargets="GenerateUnoSplashScreens"
+		Condition="'$(DesignTimeBuild)' != 'True'">
+        <!-- iOS, but not Catalyst -->
+		<GenerateSplashStoryboard_v0
+            Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'"
+            OutputFile="$(_UnoIntermediateStoryboard)"
+            UnoSplashScreen="@(UnoSplashScreen)"
+        />
+        <PropertyGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+            <_UnoIntermediateSplashScreenFile>$(_UnoIntermediateStoryboard)</_UnoIntermediateSplashScreenFile>
+        </PropertyGroup>
+        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+            <InterfaceDefinition Include="$(_UnoIntermediateStoryboard)" Link="$([System.IO.Path]::GetFileName($(_UnoIntermediateStoryboard)))" />
+            <FileWrites Include="$(_UnoIntermediateStoryboard)" />
+        </ItemGroup>
+
+        <!-- Create a partial info.plist for iOS -->
+        <CreatePartialInfoPlistTask_v0
+            Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' And '$(_UnoIntermediateSplashScreenFile)' != ''"
+            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+            PlistName="UnoInfo.plist"
+            Storyboard="$(_UnoIntermediateSplashScreenFile)" />
+    </Target>
+
+    <Target Name="ProcessUnoSplashScreens"
+        AfterTargets="GenerateUnoSplashApple"
+        DependsOnTargets="GenerateUnoSplashApple"
+        Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+
+        <!-- iOS, but not Catalyst -->
+        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' ">
+			<_UnoSplashPListFiles Include="$(_UnoIntermediateSplashScreen)UnoInfo.plist" Condition="Exists('$(_UnoIntermediateSplashScreen)UnoInfo.plist')" />
+			<PartialAppManifest Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
+			<FileWrites Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
+		</ItemGroup>
+
+		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+			<_UnoAssetsToCopyToBuildServer Include="@(_UnoSplashPListFiles)">
+				<TargetPath>%(Identity)</TargetPath>
+			</_UnoAssetsToCopyToBuildServer>
+		</ItemGroup>
+		<CopyFilesToBuildServer
+			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
+			SessionId="$(BuildSessionId)"
+			Files="@(_UnoAssetsToCopyToBuildServer)" />
+    </Target>
+
+    <Target
+		Name="ProcessResizedImagesApple_v0"
+		AfterTargets="ProcessResizedImages_v0"
+		DependsOnTargets="ProcessResizedImages_v0"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'">
+			<_UnoResizetizerCollectedBundleResourceImages Include="@(_UnoResizetizerCollectedImages->'%(FullPath)')">
+				<LogicalName>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</LogicalName>
+				<TargetPath>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</TargetPath>
+			</_UnoResizetizerCollectedBundleResourceImages>
+
+			<ImageAsset
+				Include="@(_UnoResizetizerCollectedBundleResourceImages)"
+				Condition="'@(_UnoResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_UnoResizetizerCollectedBundleResourceImages.Identity)' != ''">
+				<LogicalName>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</LogicalName>
+				<TargetPath>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</TargetPath>
+				<Link>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</Link>
+			</ImageAsset>
+		</ItemGroup>
+
+		<!-- iOS Only -->
+		<!-- If on Windows, using build host, copy the files over to build server host too -->
+		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
+			<_UnoImagesToCopyToBuildServer Include="@(_UnoResizetizerCollectedBundleResourceImages)">
+				<TargetPath>%(Identity)</TargetPath>
+			</_UnoImagesToCopyToBuildServer>
+		</ItemGroup>
+		<CopyFilesToBuildServer
+			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
+			SessionId="$(BuildSessionId)"
+			Files="@(_UnoImagesToCopyToBuildServer)" />
+    </Target>
+</Project>

--- a/src/.nuspec/Uno.Resizetizer.apple.targets
+++ b/src/.nuspec/Uno.Resizetizer.apple.targets
@@ -1,41 +1,41 @@
 <Project>
-    <Target
-        Name="GenerateUnoSplashApple"
-		AfterTargets="GenerateUnoSplashScreens"
-		DependsOnTargets="GenerateUnoSplashScreens"
-		Condition="'$(DesignTimeBuild)' != 'True'">
-        <!-- iOS, but not Catalyst -->
+	<Target
+			Name="GenerateUnoSplashApple"
+			AfterTargets="GenerateUnoSplashScreens"
+			DependsOnTargets="GenerateUnoSplashScreens"
+			Condition="'$(DesignTimeBuild)' != 'True'">
+		<!-- iOS, but not Catalyst -->
 		<GenerateSplashStoryboard_v0
-            Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'"
-            OutputFile="$(_UnoIntermediateStoryboard)"
-            UnoSplashScreen="@(UnoSplashScreen)"
-        />
-        <PropertyGroup Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'">
-            <_UnoIntermediateSplashScreenFile>$(_UnoIntermediateStoryboard)</_UnoIntermediateSplashScreenFile>
-        </PropertyGroup>
-        <ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
-            <InterfaceDefinition Include="$(_UnoIntermediateStoryboard)" Link="$([System.IO.Path]::GetFileName($(_UnoIntermediateStoryboard)))" />
-            <FileWrites Include="$(_UnoIntermediateStoryboard)" />
-        </ItemGroup>
+				Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'"
+				OutputFile="$(_UnoIntermediateStoryboard)"
+				UnoSplashScreen="@(UnoSplashScreen)"
+		/>
+		<PropertyGroup Condition="'$(TargetPlatformIdentifier)' != 'maccatalyst'">
+			<_UnoIntermediateSplashScreenFile>$(_UnoIntermediateStoryboard)</_UnoIntermediateSplashScreenFile>
+		</PropertyGroup>
+		<ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+			<InterfaceDefinition Include="$(_UnoIntermediateStoryboard)" Link="$([System.IO.Path]::GetFileName($(_UnoIntermediateStoryboard)))"/>
+			<FileWrites Include="$(_UnoIntermediateStoryboard)"/>
+		</ItemGroup>
 
-        <!-- Create a partial info.plist for iOS -->
-        <CreatePartialInfoPlistTask_v0
-            Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' And '$(_UnoIntermediateSplashScreenFile)' != ''"
-            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-            PlistName="UnoInfo.plist"
-            Storyboard="$(_UnoIntermediateSplashScreenFile)" />
-    </Target>
+		<!-- Create a partial info.plist for iOS -->
+		<CreatePartialInfoPlistTask_v0
+				Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' And '$(_UnoIntermediateSplashScreenFile)' != ''"
+				IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+				PlistName="UnoInfo.plist"
+				Storyboard="$(_UnoIntermediateSplashScreenFile)"/>
+	</Target>
 
-    <Target Name="ProcessUnoSplashScreens"
-        AfterTargets="GenerateUnoSplashApple"
-        DependsOnTargets="GenerateUnoSplashApple"
-        Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+	<Target Name="ProcessUnoSplashScreens"
+			AfterTargets="GenerateUnoSplashApple"
+			DependsOnTargets="GenerateUnoSplashApple"
+			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
 
-        <!-- iOS, but not Catalyst -->
-        <ItemGroup>
-			<_UnoSplashPListFiles Include="$(_UnoIntermediateSplashScreen)UnoInfo.plist" Condition="Exists('$(_UnoIntermediateSplashScreen)UnoInfo.plist')" />
-			<PartialAppManifest Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
-			<FileWrites Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
+		<!-- iOS, but not Catalyst -->
+		<ItemGroup>
+			<_UnoSplashPListFiles Include="$(_UnoIntermediateSplashScreen)UnoInfo.plist" Condition="Exists('$(_UnoIntermediateSplashScreen)UnoInfo.plist')"/>
+			<PartialAppManifest Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''"/>
+			<FileWrites Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''"/>
 		</ItemGroup>
 
 		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'">
@@ -44,25 +44,25 @@
 			</_UnoAssetsToCopyToBuildServer>
 		</ItemGroup>
 		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
-			SessionId="$(BuildSessionId)"
-			Files="@(_UnoAssetsToCopyToBuildServer)" />
-    </Target>
+				Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
+				SessionId="$(BuildSessionId)"
+				Files="@(_UnoAssetsToCopyToBuildServer)"/>
+	</Target>
 
-    <Target
-		Name="ProcessResizedImagesApple_v0"
-		AfterTargets="ProcessResizedImages_v0"
-		DependsOnTargets="ProcessResizedImages_v0"
-		Condition="'$(DesignTimeBuild)' != 'true'">
-        <ItemGroup>
+	<Target
+			Name="ProcessResizedImagesApple_v0"
+			AfterTargets="ProcessResizedImages_v0"
+			DependsOnTargets="ProcessResizedImages_v0"
+			Condition="'$(DesignTimeBuild)' != 'true'">
+		<ItemGroup>
 			<_UnoResizetizerCollectedBundleResourceImages Include="@(_UnoResizetizerCollectedImages->'%(FullPath)')">
 				<LogicalName>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</LogicalName>
 				<TargetPath>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</TargetPath>
 			</_UnoResizetizerCollectedBundleResourceImages>
 
 			<ImageAsset
-				Include="@(_UnoResizetizerCollectedBundleResourceImages)"
-				Condition="'@(_UnoResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_UnoResizetizerCollectedBundleResourceImages.Identity)' != ''">
+					Include="@(_UnoResizetizerCollectedBundleResourceImages)"
+					Condition="'@(_UnoResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_UnoResizetizerCollectedBundleResourceImages.Identity)' != ''">
 				<LogicalName>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</LogicalName>
 				<TargetPath>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</TargetPath>
 				<Link>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</Link>
@@ -77,8 +77,8 @@
 			</_UnoImagesToCopyToBuildServer>
 		</ItemGroup>
 		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
-			SessionId="$(BuildSessionId)"
-			Files="@(_UnoImagesToCopyToBuildServer)" />
-    </Target>
+				Condition="'$(BuildSessionId)' != '' And '$(IsMacEnabled)'=='true'"
+				SessionId="$(BuildSessionId)"
+				Files="@(_UnoImagesToCopyToBuildServer)"/>
+	</Target>
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -100,6 +100,9 @@
 		<_UnoResizetizerIsWasmApp Condition="'$(UnoRuntimeIdentifier)' == 'WebAssembly'">True</_UnoResizetizerIsWasmApp>
 	</PropertyGroup>
 
+	<Import Project="Uno.Resizetizer.android.targets" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
+	<Import Project="Uno.Resizetizer.apple.targets" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerPlatformIsMacCatalyst)' == 'True'" />
+
 	<PropertyGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True' Or '$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsWasmApp)' == 'True'">
 		<_UnoResizetizerIsCompatibleApp>True</_UnoResizetizerIsCompatibleApp>
 
@@ -360,10 +363,13 @@
 		</GetUnoAssetPath_v0>
 	</Target>
 
-	<Target Name="ProcessUnoSplashScreens"
-				Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+	<Target Name="GenerateUnoSplashScreens"
+			BeforeTargets="ProcessUnoSplashScreens"
+			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'"
+			Inputs="$(_UnoSplashInputsFile);@(UnoSplashScreen)"
+			Outputs="$(_UnoSplashStampFile)">
 
-		<Warning
+			<Warning
 			Condition="'@(UnoSplashScreen->Count())' &gt; '1'"
 			Text="More than one 'UnoSplashScreen' is defined; only the first will be used."
 		/>
@@ -379,13 +385,25 @@
 		<Warning Condition="'%(UnoSplashScreen.Link)' != ''"
 				 Text ="The UnoSplashScreen.Link property will be ignored." />
 
+				 
 		<!--If not Windows-->
 		<ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' Or $(_UnoResizetizerIsSkiaApp) == 'True' or '$(_UnoResizetizerIsAndroidApp)' == 'True' or ('$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst')">
 			<UnoImage Include="@(UnoSplashScreen)" IsSplashScreen="True" Link=""/>
 		</ItemGroup>
 
-		<!--Wasm-->
+		<MakeDir Directories="$(IntermediateOutputPath)"/>
+		<!-- Stamp file for Outputs -->
+		<Touch Files="$(_UnoSplashStampFile)" AlwaysCreate="True" />
+		<ItemGroup>
+			<FileWrites Include="$(_UnoSplashStampFile)" />
+		</ItemGroup>
 
+	</Target>
+
+	<Target Name="ProcessUnoSplashScreens"
+				Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+
+		<!--Wasm-->
 		<GenerateWasmSplashAssets_v0
 			Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
 			IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
@@ -404,56 +422,6 @@
 								Link="$(UserAppManifest)"/>
 		</ItemGroup>
 
-		<!-- Android -->
-		<GenerateSplashAndroidResources_v0
-			Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'"
-			IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-			UnoSplashScreen="@(UnoSplashScreen)"
-		/>
-		<ItemGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'">
-			<LibraryResourceDirectories Condition="Exists('$(_UnoIntermediateSplashScreen)')" Include="$(_UnoIntermediateSplashScreen)">
-				<StampFile>$(_UnoResizetizerStampFile)</StampFile>
-			</LibraryResourceDirectories>
-			<FileWrites Include="$(_UnoIntermediateSplashScreen)**\*" />
-		</ItemGroup>
-
-		<!-- iOS, but not Catalyst -->
-		<GenerateSplashStoryboard_v0
-			Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'"
-			OutputFile="$(_UnoIntermediateStoryboard)"
-			UnoSplashScreen="@(UnoSplashScreen)"
-		/>
-		<PropertyGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
-			<_UnoIntermediateSplashScreenFile>$(_UnoIntermediateStoryboard)</_UnoIntermediateSplashScreenFile>
-		</PropertyGroup>
-		<ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
-			<InterfaceDefinition Include="$(_UnoIntermediateStoryboard)" Link="$([System.IO.Path]::GetFileName($(_UnoIntermediateStoryboard)))" />
-			<FileWrites Include="$(_UnoIntermediateStoryboard)" />
-		</ItemGroup>
-
-		<!-- Create a partial info.plist for iOS -->
-		<CreatePartialInfoPlistTask_v0
-			Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' And '$(_UnoIntermediateSplashScreenFile)' != ''"
-			IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-			PlistName="UnoInfo.plist"
-			Storyboard="$(_UnoIntermediateSplashScreenFile)" />
-
-		<ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' ">
-			<_UnoSplashPListFiles Include="$(_UnoIntermediateSplashScreen)UnoInfo.plist" Condition="Exists('$(_UnoIntermediateSplashScreen)UnoInfo.plist')" />
-			<PartialAppManifest Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
-			<FileWrites Include="@(_UnoSplashPListFiles)" Condition="'@(_UnoSplashPListFiles)' != ''" />
-		</ItemGroup>
-
-		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-			<_UnoAssetsToCopyToBuildServer Include="@(_UnoSplashPListFiles)">
-				<TargetPath>%(Identity)</TargetPath>
-			</_UnoAssetsToCopyToBuildServer>
-		</ItemGroup>
-		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
-			SessionId="$(BuildSessionId)"
-			Files="@(_UnoAssetsToCopyToBuildServer)" />
-
 		<!-- UWP / WinUI -->
 		<ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
 			<UnoWindowsSplash Include="@(UnoSplashScreen)" Link=""/>
@@ -469,13 +437,6 @@
 				<TargetPath>%(_UnoSplashAssets.Filename)%(_UnoSplashAssets.Extension)</TargetPath>
 			</ContentWithTargetPath>
 			<FileWrites Include="@(_UnoSplashAssets)" />
-		</ItemGroup>
-
-		<MakeDir Directories="$(IntermediateOutputPath)"/>
-		<!-- Stamp file for Outputs -->
-		<Touch Files="$(_UnoSplashStampFile)" AlwaysCreate="True" />
-		<ItemGroup>
-			<FileWrites Include="$(_UnoSplashStampFile)" />
 		</ItemGroup>
 	</Target>
 
@@ -529,24 +490,6 @@
 			<AppIconPath Condition="'$(AppIconPath)' == ''">%(_AppIconItemGroup.Identity)</AppIconPath>
 		</PropertyGroup>
 
-
-		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' != 'True'">
-			<Content Include="@(_UnoResizetizerCollectedImages)"
-					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)"
-					 TargetPath="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)">
-			</Content>
-
-			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
-		</ItemGroup>
-
-		<!--
-		Disables "XA0101 build action is not supported" as Uno handles Content items explicitly
-		https://github.com/xamarin/xamarin-android/blob/311b41e864a0162895d079477cb9398fbec5ca6e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L833
-		-->
-		<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
-			<Content Update="@(_UnoResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
-		</ItemGroup>
-
 		<!-- Wasm -->
 		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'">
 			<Content Include="@(_UnoResizetizerCollectedImages->FullPath())"
@@ -574,41 +517,6 @@
 					 Link="$(WasmPWAManifestFile)" />
 		</ItemGroup>
 
-		<!-- Android -->
-		<ItemGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'">
-			<AndroidResource Include="@(_UnoResizetizerCollectedAppIcons)"
-					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)" >
-			</AndroidResource>
-		</ItemGroup>
-
-
-		<ItemGroup Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'">
-			<_UnoResizetizerCollectedBundleResourceImages Include="@(_UnoResizetizerCollectedImages->'%(FullPath)')">
-				<LogicalName>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</LogicalName>
-				<TargetPath>%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)</TargetPath>
-			</_UnoResizetizerCollectedBundleResourceImages>
-
-			<ImageAsset
-				Include="@(_UnoResizetizerCollectedBundleResourceImages)"
-				Condition="'@(_UnoResizetizerCollectedBundleResourceImages->Contains('Assets.xcassets'))' == 'True' and '%(_UnoResizetizerCollectedBundleResourceImages.Identity)' != ''">
-				<LogicalName>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</LogicalName>
-				<TargetPath>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</TargetPath>
-				<Link>Assets.xcassets\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(_UnoResizetizerCollectedBundleResourceImages.Identity)))))\%(_UnoResizetizerCollectedBundleResourceImages.Filename)%(_UnoResizetizerCollectedBundleResourceImages.Extension)</Link>
-			</ImageAsset>
-		</ItemGroup>
-
-		<!-- iOS Only -->
-		<!-- If on Windows, using build host, copy the files over to build server host too -->
-		<ItemGroup Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'">
-			<_UnoImagesToCopyToBuildServer Include="@(_UnoResizetizerCollectedBundleResourceImages)">
-				<TargetPath>%(Identity)</TargetPath>
-			</_UnoImagesToCopyToBuildServer>
-		</ItemGroup>
-		<CopyFilesToBuildServer
-			Condition="'$(BuildSessionId)' != '' And '$(_UnoResizetizerIsiOSApp)' == 'True' And '$(IsMacEnabled)'=='true'"
-			SessionId="$(BuildSessionId)"
-			Files="@(_UnoImagesToCopyToBuildServer)" />
-
 		<PropertyGroup>
 			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>
 		</PropertyGroup>
@@ -620,6 +528,29 @@
 		<!-- Include our images and stamp file as filewrites so they don't get rm'd -->
 		<ItemGroup>
 			<FileWrites Include="$(_UnoResizetizerStampFile)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="ProcessResizedImages_v0"
+			AfterTargets="UnoResizetizeImages"
+			DependsOnTargets="UnoResizetizeImages"
+			Condition="'$(DesignTimeBuild)' != 'true'">
+		
+		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' != 'True'">
+			<Content Include="@(_UnoResizetizerCollectedImages)"
+					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)"
+					 TargetPath="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)">
+			</Content>
+
+			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
+		</ItemGroup>
+
+		<!--
+		Disables "XA0101 build action is not supported" as Uno handles Content items explicitly
+		https://github.com/xamarin/xamarin-android/blob/311b41e864a0162895d079477cb9398fbec5ca6e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L833
+		-->
+		<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
+			<Content Update="@(_UnoResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
 		</ItemGroup>
 	</Target>
 

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -233,7 +233,7 @@
 	</PropertyGroup>
 
 	<!-- UWP / WinUI -->
-	<PropertyGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+	<PropertyGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
 		<UnoResizetizerPlatformType>uwp</UnoResizetizerPlatformType>
 
 		<UnoResizetizeBeforeTargets>
@@ -348,10 +348,10 @@
 	</Target>
 
 	<Target Name="ProcessUnoAssets">
-		<PropertyGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+		<PropertyGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
 			<_UnoAssetItemMetadata>TargetPath</_UnoAssetItemMetadata>
 		</PropertyGroup>
-		<ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+		<ItemGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
 			<!-- Windows does not recognize %(LogicalName), so we must copy it to %(Link) -->
 			<UnoAsset Update="@(UnoAsset)" Link="%(UnoAsset.LogicalName)" Condition="'%(UnoAsset.Link)' == '' And '%(UnoAsset.LogicalName)' != ''" />
 		</ItemGroup>
@@ -362,7 +362,7 @@
 			Input="@(UnoAsset)">
 			<Output ItemName="AndroidAsset"          TaskParameter="Output" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
 			<Output ItemName="Content"               TaskParameter="Output" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'" />
-			<Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'" />
+			<Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'" />
 		</GetUnoAssetPath_v0>
 	</Target>
 

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -103,6 +103,7 @@
 	<Import Project="Uno.Resizetizer.android.targets" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
 	<Import Project="Uno.Resizetizer.wasm.targets" Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'" />
 	<Import Project="Uno.Resizetizer.apple.targets" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerPlatformIsMacCatalyst)' == 'True'" />
+	<Import Project="Uno.Resizetizer.windows.skia.targets" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
 	
 
 	<PropertyGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True' Or '$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsWasmApp)' == 'True'">
@@ -487,72 +488,6 @@
 		<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
 			<Content Update="@(_UnoResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
 		</ItemGroup>
-	</Target>
-
-	<!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly depends
-		 on "_ValidatePresenceOfAppxManifestItems" and we need to get in before then. -->
-	<Target Name="_UnoValidatePresenceOfAppxManifestItemsBeforeTarget"
-			BeforeTargets="_ValidatePresenceOfAppxManifestItems"
-			DependsOnTargets="UnoGeneratePackageAppxManifest"
-			Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
-
-	<Target Name="UnoGeneratePackageAppxManifest"
-			Condition="('$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
-			DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
-			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
-			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
-			Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
-
-
-		<PropertyGroup>
-			<_MauiWindowsApplicationId Condition="'$(_MauiWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">$(ApplicationIdGuid)</_MauiWindowsApplicationId>
-			<_MauiWindowsApplicationId Condition="'$(_MauiWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">$(ApplicationId)</_MauiWindowsApplicationId>
-		</PropertyGroup>
-
-		<GeneratePackageAppxManifest_v0
-			IntermediateOutputPath="$(_UnoIntermediateManifest)"
-			AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
-			GeneratedFilename="Package.appxmanifest"
-			ApplicationId="$(_MauiWindowsApplicationId)"
-			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
-			ApplicationVersion="$(ApplicationVersion)"
-			ApplicationTitle="$(ApplicationTitle)"
-			AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
-			SplashScreen="@(UnoSplashScreen)" />
-
-		<!-- replace user manifest -->
-		<ItemGroup Condition="'@(AppxManifest)' != ''">
-			<AppxManifest Remove="@(AppxManifest)" />
-			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-		</ItemGroup>
-		<ItemGroup Condition="'@(_SkiaManifest)' != '' ">
-			<AppxManifest Remove="@(AppxManifest)" />
-			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-			
-			<!--If there's no LogicalName, we use the default name-->
-			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-								Link="%(_SkiaManifest.Link)"
-								LogicalName="Package.appxmanifest"
-								Condition="%(_SkiaManifest.LogicalName) == '' "/>
-
-			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-								Link="%(_SkiaManifest.Link)"
-								LogicalName="%(_SkiaManifest.LogicalName)"
-								Condition="%(_SkiaManifest.LogicalName) != '' "/>
-
-		</ItemGroup>
-		<ItemGroup Condition="'@(_UnoAppxManifest)' != ''">
-			<_UnoAppxManifest Remove="@(_UnoAppxManifest)" />
-			<_UnoAppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-		</ItemGroup>
-
-		<MakeDir Directories="$(IntermediateOutputPath)"/>
-		<!-- Stamp file for Outputs -->
-		<Touch Files="$(_UnoManifestStampFile)" AlwaysCreate="True" />
-		<ItemGroup>
-			<FileWrites Include="$(_UnoManifestStampFile)" />
-		</ItemGroup>
-
 	</Target>
 
 	<Target Name="_CleanUnoResizetizer">

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -101,7 +101,9 @@
 	</PropertyGroup>
 
 	<Import Project="Uno.Resizetizer.android.targets" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
+	<Import Project="Uno.Resizetizer.wasm.targets" Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'" />
 	<Import Project="Uno.Resizetizer.apple.targets" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerPlatformIsMacCatalyst)' == 'True'" />
+	
 
 	<PropertyGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True' Or '$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsWasmApp)' == 'True'">
 		<_UnoResizetizerIsCompatibleApp>True</_UnoResizetizerIsCompatibleApp>
@@ -400,46 +402,6 @@
 
 	</Target>
 
-	<Target Name="ProcessUnoSplashScreens"
-				Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
-
-		<!--Wasm-->
-		<GenerateWasmSplashAssets_v0
-			Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
-			IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-			EmbeddedResources="@(EmbeddedResource)"
-			UnoSplashScreen="@(UnoSplashScreen)"
-			OutputFile="$(_UnoIntermediateAppManifestWasm)">
-
-			<Output PropertyName="UserAppManifest"
-					TaskParameter="UserAppManifest" />
-
-		</GenerateWasmSplashAssets_v0>
-
-		<ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' And $(UserAppManifest) != ''">
-			<EmbeddedResource Remove="$(UserAppManifest)" />
-			<EmbeddedResource Include="$(_UnoIntermediateAppManifestWasm)"
-								Link="$(UserAppManifest)"/>
-		</ItemGroup>
-
-		<!-- UWP / WinUI -->
-		<ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
-			<UnoWindowsSplash Include="@(UnoSplashScreen)" Link=""/>
-		</ItemGroup>
-		<GenerateSplashAssets_v0
-			Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
-			IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-			UnoSplashScreen="@(UnoWindowsSplash)"
-		/>
-		<ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
-			<_UnoSplashAssets Include="$(_UnoIntermediateSplashScreen)**\*" />
-			<ContentWithTargetPath Include="@(_UnoSplashAssets)">
-				<TargetPath>%(_UnoSplashAssets.Filename)%(_UnoSplashAssets.Extension)</TargetPath>
-			</ContentWithTargetPath>
-			<FileWrites Include="@(_UnoSplashAssets)" />
-		</ItemGroup>
-	</Target>
-
 	<Target Name="UnoResizetizeImages"
 		Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);@(UnoImage)"
 		Outputs="$(_UnoResizetizerStampFile)"
@@ -489,33 +451,6 @@
 			<!-- If the AppIcon property is empty we can try to find it on the disk -->
 			<AppIconPath Condition="'$(AppIconPath)' == ''">%(_AppIconItemGroup.Identity)</AppIconPath>
 		</PropertyGroup>
-
-		<!-- Wasm -->
-		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'">
-			<Content Include="@(_UnoResizetizerCollectedImages->FullPath())"
-					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)" >
-			</Content>
-
-			<Content Include="@(_UnoResizetizerCollectedAppIcons->FullPath())"
-					 Condition="'%(Extension)' != '.ico'"
-					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)"/>
-
-			<Content Include="@(_UnoResizetizerCollectedAppIcons->FullPath())"
-					 Condition="'%(Extension)' == '.ico'"
-					 UnoDeploy="Root"
-					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)"/>
-
-			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
-		</ItemGroup>
-
-		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True' And '$(UnoResizetizerPwaManifest)' != ''">
-			<Content Remove="$(WasmPWAManifestFile)" />
-			<Content Include="$(UnoResizetizerPwaManifest)"
-					 CopyToOutputDirectory="PreserveNewest"
-					 ExcludeFromSingleFile ="True"
-					 CopyToPublishDirectory ="PreserveNewest"
-					 Link="$(WasmPWAManifestFile)" />
-		</ItemGroup>
 
 		<PropertyGroup>
 			<ApplicationIcon Condition="'$(ApplicationIcon)' == ''">$(AppIconPath)</ApplicationIcon>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<ItemGroup>
-		<AvailableItemName Include="UnoAsset" />
-		<AvailableItemName Include="UnoImage" />
-		<AvailableItemName Include="UnoIcon" />
-		<AvailableItemName Include="UnoSplashScreen" />
+		<AvailableItemName Include="UnoAsset"/>
+		<AvailableItemName Include="UnoImage"/>
+		<AvailableItemName Include="UnoIcon"/>
+		<AvailableItemName Include="UnoSplashScreen"/>
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -13,44 +13,44 @@
 	</PropertyGroup>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.ResizetizeImages_v0" />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.ResizetizeImages_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.DetectInvalidResourceOutputFilenamesTask_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.DetectInvalidResourceOutputFilenamesTask_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.CreatePartialInfoPlistTask_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.CreatePartialInfoPlistTask_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GenerateSplashAndroidResources_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GenerateSplashAndroidResources_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GenerateSplashStoryboard_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GenerateSplashStoryboard_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GenerateSplashAssets_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GenerateSplashAssets_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GetUnoAssetPath_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GetUnoAssetPath_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GeneratePackageAppxManifest_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GeneratePackageAppxManifest_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.GenerateWasmSplashAssets_v0"  />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.GenerateWasmSplashAssets_v0"/>
 
 	<UsingTask
-		AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-		TaskName="Uno.Resizetizer.WindowIconGeneratorTask_V0" />
+			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
+			TaskName="Uno.Resizetizer.WindowIconGeneratorTask_V0"/>
 
 	<PropertyGroup>
 		<CleanDependsOn>
@@ -84,7 +84,7 @@
 
 		<UnoResizetizerIncludeSelfProject Condition="'$(UnoResizetizerIncludeSelfProject)' == ''">False</UnoResizetizerIncludeSelfProject>
 
-		<_UnoResizetizerDefaultInvalidFilenamesErrorMessage>One or more invalid file names were detected.  File names must be lowercase, start and end with a letter character, and contain only alphanumeric characters or underscores: </_UnoResizetizerDefaultInvalidFilenamesErrorMessage>
+		<_UnoResizetizerDefaultInvalidFilenamesErrorMessage>One or more invalid file names were detected. File names must be lowercase, start and end with a letter character, and contain only alphanumeric characters or underscores:</_UnoResizetizerDefaultInvalidFilenamesErrorMessage>
 
 		<_WasmHasPWAManifest>False</_WasmHasPWAManifest>
 		<_WasmHasPWAManifest Condition="'$(WasmPWAManifestFile)' != ''">True</_WasmHasPWAManifest>
@@ -100,11 +100,11 @@
 		<_UnoResizetizerIsWasmApp Condition="'$(UnoRuntimeIdentifier)' == 'WebAssembly'">True</_UnoResizetizerIsWasmApp>
 	</PropertyGroup>
 
-	<Import Project="Uno.Resizetizer.android.targets" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
-	<Import Project="Uno.Resizetizer.wasm.targets" Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'" />
-	<Import Project="Uno.Resizetizer.apple.targets" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerPlatformIsMacCatalyst)' == 'True'" />
-	<Import Project="Uno.Resizetizer.windows.skia.targets" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
-	
+	<Import Project="Uno.Resizetizer.android.targets" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'"/>
+	<Import Project="Uno.Resizetizer.wasm.targets" Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'"/>
+	<Import Project="Uno.Resizetizer.apple.targets" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerPlatformIsMacCatalyst)' == 'True'"/>
+	<Import Project="Uno.Resizetizer.windows.skia.targets" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'"/>
+
 
 	<PropertyGroup Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True' Or '$(_UnoResizetizerIsiOSApp)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsWasmApp)' == 'True'">
 		<_UnoResizetizerIsCompatibleApp>True</_UnoResizetizerIsCompatibleApp>
@@ -260,90 +260,90 @@
 
 	<!-- Uno Icon -->
 	<ItemGroup>
-		<_WindowIconExtension Include="$(_UnoResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs" />
+		<_WindowIconExtension Include="$(_UnoResizetizerIntermediateOutputRoot)Uno.Resizetizer.WindowIconExtensions.g.cs"/>
 	</ItemGroup>
 
 	<!-- Finds absolute paths to any UnoImage in this project -->
 	<!-- App head projects will invoke this target on their project references to collect images -->
 	<Target Name="GetUnoItems" Outputs="@(ExportedUnoItem)">
 		<ItemGroup>
-			<UnoItem Include="@(UnoImage)" ItemGroupName="UnoImage" Condition="'%(UnoImage.ForegroundFile)' == ''" />
-			<UnoItem Include="@(UnoImage)" ItemGroupName="UnoImage" Condition="'%(UnoImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(UnoImage.ForegroundFile)'))" ProjectDirectory="$(MSBuildProjectDirectory)" />
-			<UnoItem Include="@(UnoIcon)" ItemGroupName="UnoIcon" Condition="'%(UnoIcon.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(UnoIcon.ForegroundFile)'))" />
-			<UnoItem Include="@(UnoAsset)" ItemGroupName="UnoAsset" ProjectDirectory="$(MSBuildProjectDirectory)" />
-			<UnoItem Include="@(UnoSplashScreen)" ItemGroupName="UnoSplashScreen" />
+			<UnoItem Include="@(UnoImage)" ItemGroupName="UnoImage" Condition="'%(UnoImage.ForegroundFile)' == ''"/>
+			<UnoItem Include="@(UnoImage)" ItemGroupName="UnoImage" Condition="'%(UnoImage.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(UnoImage.ForegroundFile)'))" ProjectDirectory="$(MSBuildProjectDirectory)"/>
+			<UnoItem Include="@(UnoIcon)" ItemGroupName="UnoIcon" Condition="'%(UnoIcon.ForegroundFile)' != ''" ForegroundFile="$([System.IO.Path]::GetFullPath('%(UnoIcon.ForegroundFile)'))"/>
+			<UnoItem Include="@(UnoAsset)" ItemGroupName="UnoAsset" ProjectDirectory="$(MSBuildProjectDirectory)"/>
+			<UnoItem Include="@(UnoSplashScreen)" ItemGroupName="UnoSplashScreen"/>
 		</ItemGroup>
 
 		<ConvertToAbsolutePath Paths="@(UnoItem)">
-			<Output TaskParameter="AbsolutePaths" ItemName="ExportedUnoItem" />
+			<Output TaskParameter="AbsolutePaths" ItemName="ExportedUnoItem"/>
 		</ConvertToAbsolutePath>
 	</Target>
 
 
 	<!-- Collect images from referenced projects -->
 	<Target Name="UnoResizetizeCollectItems"
-		Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True' And '$(DisableUnoResizetizer)' != 'true'"
-		BeforeTargets="$(UnoResizetizeCollectItemsBeforeTargets)"
-		AfterTargets="$(UnoResizetizeCollectItemsAfterTargets)">
+			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True' And '$(DisableUnoResizetizer)' != 'true'"
+			BeforeTargets="$(UnoResizetizeCollectItemsBeforeTargets)"
+			AfterTargets="$(UnoResizetizeCollectItemsAfterTargets)">
 
 		<CallTarget Targets="GetUnoItems" Condition="'$(UnoResizetizerIncludeSelfProject)' == 'True'">
 			<Output
-				TaskParameter="TargetOutputs"
-				ItemName="ImportedUnoItem" />
+					TaskParameter="TargetOutputs"
+					ItemName="ImportedUnoItem"/>
 		</CallTarget>
 
 		<ItemGroup>
 			<UnoImage
-				Include="@(ImportedUnoItem)"
-				Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoImage'"/>
+					Include="@(ImportedUnoItem)"
+					Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoImage'"/>
 			<UnoIcon
-				Include="@(ImportedUnoItem)"
-				Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoIcon'" />
+					Include="@(ImportedUnoItem)"
+					Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoIcon'"/>
 			<UnoAsset
-				Include="@(ImportedUnoItem)"
-				Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoAsset'" />
+					Include="@(ImportedUnoItem)"
+					Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoAsset'"/>
 			<UnoSplashScreen
-				Include="@(ImportedUnoItem)"
-				Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoSplashScreen'" />
+					Include="@(ImportedUnoItem)"
+					Condition="'%(ImportedUnoItem.ItemGroupName)' == 'UnoSplashScreen'"/>
 		</ItemGroup>
 
 		<!-- Make sure animated gifs are not resized by default -->
 		<ItemGroup>
-			<UnoImage Update="@(UnoImage)" Resize="False" Condition="'%(UnoImage.Extension)' == '.gif' and '%(UnoImage.Resize)' == ''" />
+			<UnoImage Update="@(UnoImage)" Resize="False" Condition="'%(UnoImage.Extension)' == '.gif' and '%(UnoImage.Resize)' == ''"/>
 		</ItemGroup>
 
 		<Warning Condition="'%(UnoIcon.Link)' != ''"
-				 Text ="The UnoIcon.Link property will be ignored." />
+				 Text="The UnoIcon.Link property will be ignored."/>
 
 		<!-- Map @(UnoIcon) to @(UnoImage IsAppIcon=true) -->
 		<ItemGroup>
-			<UnoImage Include="@(UnoIcon)" IsAppIcon="True" Link="" />
+			<UnoImage Include="@(UnoIcon)" IsAppIcon="True" Link=""/>
 		</ItemGroup>
 
 		<!-- Write out item spec and metadata to a file we can use as an inputs for the resize target -->
 		<!-- This allows us to invalidate the build based on not just input image files changing but project item metadata as well -->
 		<WriteLinesToFile
-			File="$(_UnoResizetizerInputsFile)"
-			Lines="@(UnoImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
-			Overwrite="true"
-			WriteOnlyWhenDifferent="true" />
+				File="$(_UnoResizetizerInputsFile)"
+				Lines="@(UnoImage->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);IsAppIcon=%(IsAppIcon);ForegroundScale=%(ForegroundScale);ForegroundFile=%(ForegroundFile)')"
+				Overwrite="true"
+				WriteOnlyWhenDifferent="true"/>
 
 		<WriteLinesToFile
-			File="$(_UnoSplashInputsFile)"
-			Lines="@(UnoSplashScreen->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);ForegroundScale=%(ForegroundScale)')"
-			Overwrite="true"
-			WriteOnlyWhenDifferent="true" />
+				File="$(_UnoSplashInputsFile)"
+				Lines="@(UnoSplashScreen->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);ForegroundScale=%(ForegroundScale)')"
+				Overwrite="true"
+				WriteOnlyWhenDifferent="true"/>
 
 		<ItemGroup>
-			<FileWrites Include="$(_UnoResizetizerInputsFile)" />
-			<FileWrites Include="$(_UnoSplashInputsFile)" />
+			<FileWrites Include="$(_UnoResizetizerInputsFile)"/>
+			<FileWrites Include="$(_UnoSplashInputsFile)"/>
 		</ItemGroup>
 		<ItemGroup>
 			<_SkiaManifest Include="@(EmbeddedResource)"
-							 Condition="%(Extension) == '.appxmanifest'"/>
+						   Condition="%(Extension) == '.appxmanifest'"/>
 
 			<EmbeddedResource Remove="@(EmbeddedResource)"
-								Condition="%(Extension) == '.appxmanifest'"/>
+							  Condition="%(Extension) == '.appxmanifest'"/>
 		</ItemGroup>
 	</Target>
 
@@ -353,16 +353,16 @@
 		</PropertyGroup>
 		<ItemGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
 			<!-- Windows does not recognize %(LogicalName), so we must copy it to %(Link) -->
-			<UnoAsset Update="@(UnoAsset)" Link="%(UnoAsset.LogicalName)" Condition="'%(UnoAsset.Link)' == '' And '%(UnoAsset.LogicalName)' != ''" />
+			<UnoAsset Update="@(UnoAsset)" Link="%(UnoAsset.LogicalName)" Condition="'%(UnoAsset.Link)' == '' And '%(UnoAsset.LogicalName)' != ''"/>
 		</ItemGroup>
 
 		<GetUnoAssetPath_v0
-			ProjectDirectory="$(MSBuildProjectDirectory)"
-			ItemMetadata="$(_UnoAssetItemMetadata)"
-			Input="@(UnoAsset)">
-			<Output ItemName="AndroidAsset"          TaskParameter="Output" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'" />
-			<Output ItemName="Content"               TaskParameter="Output" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'" />
-			<Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'" />
+				ProjectDirectory="$(MSBuildProjectDirectory)"
+				ItemMetadata="$(_UnoAssetItemMetadata)"
+				Input="@(UnoAsset)">
+			<Output ItemName="AndroidAsset" TaskParameter="Output" Condition="'$(_UnoResizetizerIsAndroidApp)' == 'True'"/>
+			<Output ItemName="Content" TaskParameter="Output" Condition="'$(_UnoResizetizerIsiOSApp)' == 'True'"/>
+			<Output ItemName="ContentWithTargetPath" TaskParameter="Output" Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"/>
 		</GetUnoAssetPath_v0>
 	</Target>
 
@@ -372,23 +372,23 @@
 			Inputs="$(_UnoSplashInputsFile);@(UnoSplashScreen)"
 			Outputs="$(_UnoSplashStampFile)">
 
-			<Warning
-			Condition="'@(UnoSplashScreen->Count())' &gt; '1'"
-			Text="More than one 'UnoSplashScreen' is defined; only the first will be used."
+		<Warning
+				Condition="'@(UnoSplashScreen->Count())' &gt; '1'"
+				Text="More than one 'UnoSplashScreen' is defined; only the first will be used."
 		/>
 
 		<Error
-			Condition="'@(UnoSplashScreen)' == '@(UnoIcon)'"
-			Text= "The value of UnoSplashScreen and UnoIcon cannot be the same." />
+				Condition="'@(UnoSplashScreen)' == '@(UnoIcon)'"
+				Text="The value of UnoSplashScreen and UnoIcon cannot be the same."/>
 
 		<Error
-			Condition="'@(UnoSplashScreen)' == '%(UnoIcon.ForegroundFile)'"
-			Text= "The value of UnoSplashScreen and UnoIcon cannot be the same." />
+				Condition="'@(UnoSplashScreen)' == '%(UnoIcon.ForegroundFile)'"
+				Text="The value of UnoSplashScreen and UnoIcon cannot be the same."/>
 
 		<Warning Condition="'%(UnoSplashScreen.Link)' != ''"
-				 Text ="The UnoSplashScreen.Link property will be ignored." />
+				 Text="The UnoSplashScreen.Link property will be ignored."/>
 
-				 
+
 		<!--If not Windows-->
 		<ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' Or $(_UnoResizetizerIsSkiaApp) == 'True' or '$(_UnoResizetizerIsAndroidApp)' == 'True' or ('$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst')">
 			<UnoImage Include="@(UnoSplashScreen)" IsSplashScreen="True" Link=""/>
@@ -396,37 +396,37 @@
 
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!-- Stamp file for Outputs -->
-		<Touch Files="$(_UnoSplashStampFile)" AlwaysCreate="True" />
+		<Touch Files="$(_UnoSplashStampFile)" AlwaysCreate="True"/>
 		<ItemGroup>
-			<FileWrites Include="$(_UnoSplashStampFile)" />
+			<FileWrites Include="$(_UnoSplashStampFile)"/>
 		</ItemGroup>
 
 	</Target>
 
 	<Target Name="UnoResizetizeImages"
-		Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);@(UnoImage)"
-		Outputs="$(_UnoResizetizerStampFile)"
-		AfterTargets="$(UnoResizetizeAfterTargets)"
-		Condition="'$(DesignTimeBuild)' != 'true'"
-		BeforeTargets="$(UnoResizetizeBeforeTargets)"
-		DependsOnTargets="$(UnoResizetizeDependsOnTargets)">
+			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);@(UnoImage)"
+			Outputs="$(_UnoResizetizerStampFile)"
+			AfterTargets="$(UnoResizetizeAfterTargets)"
+			Condition="'$(DesignTimeBuild)' != 'true'"
+			BeforeTargets="$(UnoResizetizeBeforeTargets)"
+			DependsOnTargets="$(UnoResizetizeDependsOnTargets)">
 
 		<DetectInvalidResourceOutputFilenamesTask_v0
-			Items="@(UnoImage->Distinct())"
-			ErrorMessage="$(_UnoResizetizerDefaultInvalidFilenamesErrorMessage)">
+				Items="@(UnoImage->Distinct())"
+				ErrorMessage="$(_UnoResizetizerDefaultInvalidFilenamesErrorMessage)">
 		</DetectInvalidResourceOutputFilenamesTask_v0>
 
 		<!-- Resize the images -->
 		<ResizetizeImages_v0
-			PlatformType="$(UnoResizetizerPlatformType)"
-			IntermediateOutputPath="$(_UnoIntermediateImages)"
-			IntermediateOutputIconPath="$(_UnoIntermediateAppIcon)"
-			PWAManifestPath="$(_WasmPwaManifestPath)"
-			InputsFile="$(_UnoResizetizerInputsFile)"
-			Images="@(UnoImage->Distinct())">
+				PlatformType="$(UnoResizetizerPlatformType)"
+				IntermediateOutputPath="$(_UnoIntermediateImages)"
+				IntermediateOutputIconPath="$(_UnoIntermediateAppIcon)"
+				PWAManifestPath="$(_WasmPwaManifestPath)"
+				InputsFile="$(_UnoResizetizerInputsFile)"
+				Images="@(UnoImage->Distinct())">
 
 			<Output PropertyName="AppIconPath"
-					TaskParameter="GeneratedIconPath" />
+					TaskParameter="GeneratedIconPath"/>
 			<Output PropertyName="AndroidIcons"
 					TaskParameter="AndroidAppIcons"/>
 			<Output PropertyName="UnoResizetizerPwaManifest"
@@ -436,10 +436,10 @@
 		<ItemGroup>
 			<!-- Get Images that were generated -->
 			<!-- Either from the task, or if the task was skipped (up to date), use the wildcard lookup -->
-			<_UnoResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)" />
+			<_UnoResizetizerCollectedImages Condition="'@(CopiedResources)' != ''" Include="@(CopiedResources)"/>
 			<_UnoResizetizerCollectedImages Condition="'@(CopiedResources)' == ''" Include="$(_UnoIntermediateImages)**\*"/>
 			<_UnoResizetizerCollectedAppIcons Include="$(_UnoIntermediateAppIcon)**\*"/>
-			
+
 			<!-- If the PWA manifest is empty we can try to find it on the disk -->
 			<_UnoUnoResizetizerPwaManifestItemGroup Condition="'$(UnoResizetizerPwaManifest)' ==''" Include="$(_UnoIntermediateAppIcon)**\*.json"/>
 			<!-- If the AppIcon property is empty we can try to find it on the disk -->
@@ -459,11 +459,11 @@
 
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<!-- Touch/create our stamp file for outputs -->
-		<Touch Files="$(_UnoResizetizerStampFile)" AlwaysCreate="True" />
+		<Touch Files="$(_UnoResizetizerStampFile)" AlwaysCreate="True"/>
 
 		<!-- Include our images and stamp file as filewrites so they don't get rm'd -->
 		<ItemGroup>
-			<FileWrites Include="$(_UnoResizetizerStampFile)" />
+			<FileWrites Include="$(_UnoResizetizerStampFile)"/>
 		</ItemGroup>
 	</Target>
 
@@ -471,14 +471,14 @@
 			AfterTargets="UnoResizetizeImages"
 			DependsOnTargets="UnoResizetizeImages"
 			Condition="'$(DesignTimeBuild)' != 'true'">
-		
+
 		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' != 'True'">
 			<Content Include="@(_UnoResizetizerCollectedImages)"
 					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)"
 					 TargetPath="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)">
 			</Content>
 
-			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
+			<FileWrites Include="@(_UnoResizetizerCollectedImages)"/>
 		</ItemGroup>
 
 		<!--
@@ -486,12 +486,12 @@
 		https://github.com/xamarin/xamarin-android/blob/311b41e864a0162895d079477cb9398fbec5ca6e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L833
 		-->
 		<ItemGroup Condition="'$(MonoAndroidAssetsPrefix)'!=''">
-			<Content Update="@(_UnoResizetizerCollectedImages)" ExcludeFromContentCheck="true" />
+			<Content Update="@(_UnoResizetizerCollectedImages)" ExcludeFromContentCheck="true"/>
 		</ItemGroup>
 	</Target>
 
 	<Target Name="_CleanUnoResizetizer">
-		<RemoveDir Directories="$(_UnoResizetizerIntermediateOutputRoot)" Condition="Exists ('$(_UnoResizetizerIntermediateOutputRoot)' )" />
+		<RemoveDir Directories="$(_UnoResizetizerIntermediateOutputRoot)" Condition="Exists ('$(_UnoResizetizerIntermediateOutputRoot)' )"/>
 	</Target>
 
 	<Target Name="_GenerateWindowUnoIconExtension"
@@ -500,12 +500,12 @@
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
-			IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
-			UnoIcons="@(UnoIcon)">
+				IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
+				UnoIcons="@(UnoIcon)">
 			<Output ItemName="GeneratedFile"
-				TaskParameter="GeneratedClass"/>
+					TaskParameter="GeneratedClass"/>
 			<Output ItemName="FilesWrite"
-				TaskParameter="GeneratedClass"/>
+					TaskParameter="GeneratedClass"/>
 		</WindowIconGeneratorTask_v0>
 	</Target>
 
@@ -514,7 +514,7 @@
 			AfterTargets="_GenerateWindowUnoIconExtension"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile">
 		<ItemGroup Condition="Exists('@(_WindowIconExtension->FullPath())')">
-			<Compile Include="@(_WindowIconExtension)" />
+			<Compile Include="@(_WindowIconExtension)"/>
 		</ItemGroup>
 	</Target>
 

--- a/src/.nuspec/Uno.Resizetizer.wasm.targets
+++ b/src/.nuspec/Uno.Resizetizer.wasm.targets
@@ -1,0 +1,77 @@
+<Project>
+    <Target
+        Name="GenerateUnoSplashWasm"
+		AfterTargets="GenerateUnoSplashScreens"
+		DependsOnTargets="GenerateUnoSplashScreens"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+
+        <!--Wasm-->
+		<GenerateWasmSplashAssets_v0
+            Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
+            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+            EmbeddedResources="@(EmbeddedResource)"
+            UnoSplashScreen="@(UnoSplashScreen)"
+            OutputFile="$(_UnoIntermediateAppManifestWasm)">
+
+            <Output PropertyName="UserAppManifest"
+                    TaskParameter="UserAppManifest" />
+        </GenerateWasmSplashAssets_v0>
+
+        <!-- Cache the $(UserAppManifest) value to be used on incremental builds-->
+		<WriteLinesToFile
+            Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
+            File="$(_UnoManifestStampFile)"
+            Lines="$(UserAppManifest)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+
+        <!-- Wasm -->
+		<ReadLinesFromFile 
+            File="$(_UnoManifestStampFile)"
+            Condition="$(_UnoResizetizerIsWasmApp) == 'True' And '$(UserAppManifest)' == ''">
+                <Output TaskParameter="Lines" PropertyName="UserAppManifest" />
+        </ReadLinesFromFile>
+
+        <ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' And $(UserAppManifest) != ''">
+            <EmbeddedResource Remove="$(UserAppManifest)" />
+            <EmbeddedResource Include="$(_UnoIntermediateAppManifestWasm)"
+                            Link="$(UserAppManifest)"/>
+        </ItemGroup>
+    </Target>
+    
+    <Target Name="ProcessUnoSplashScreens" />
+
+	<Target
+		Name="ProcessResizedImagesWasm_v0"
+		AfterTargets="ProcessResizedImages_v0"
+		DependsOnTargets="ProcessResizedImages_v0"
+		Condition="'$(DesignTimeBuild)' != 'true'">
+
+        <!-- Wasm -->
+		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'">
+			<Content Include="@(_UnoResizetizerCollectedImages->FullPath())"
+					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)" >
+			</Content>
+
+			<Content Include="@(_UnoResizetizerCollectedAppIcons->FullPath())"
+					 Condition="'%(Extension)' != '.ico'"
+					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)"/>
+
+			<Content Include="@(_UnoResizetizerCollectedAppIcons->FullPath())"
+					 Condition="'%(Extension)' == '.ico'"
+					 UnoDeploy="Root"
+					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)"/>
+
+			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
+		</ItemGroup>
+
+		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True' And '$(UnoResizetizerPwaManifest)' != ''">
+			<Content Remove="$(WasmPWAManifestFile)" />
+			<Content Include="$(UnoResizetizerPwaManifest)"
+					 CopyToOutputDirectory="PreserveNewest"
+					 ExcludeFromSingleFile ="True"
+					 CopyToPublishDirectory ="PreserveNewest"
+					 Link="$(WasmPWAManifestFile)" />
+		</ItemGroup>
+    </Target>
+</Project>

--- a/src/.nuspec/Uno.Resizetizer.wasm.targets
+++ b/src/.nuspec/Uno.Resizetizer.wasm.targets
@@ -1,54 +1,54 @@
 <Project>
-    <Target
-        Name="GenerateUnoSplashWasm"
-		AfterTargets="GenerateUnoSplashScreens"
-		DependsOnTargets="GenerateUnoSplashScreens"
-		Condition="'$(DesignTimeBuild)' != 'true'">
+	<Target
+			Name="GenerateUnoSplashWasm"
+			AfterTargets="GenerateUnoSplashScreens"
+			DependsOnTargets="GenerateUnoSplashScreens"
+			Condition="'$(DesignTimeBuild)' != 'true'">
 
-        <!--Wasm-->
+		<!--Wasm-->
 		<GenerateWasmSplashAssets_v0
-            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-            EmbeddedResources="@(EmbeddedResource)"
-            UnoSplashScreen="@(UnoSplashScreen)"
-            OutputFile="$(_UnoIntermediateAppManifestWasm)">
+				IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+				EmbeddedResources="@(EmbeddedResource)"
+				UnoSplashScreen="@(UnoSplashScreen)"
+				OutputFile="$(_UnoIntermediateAppManifestWasm)">
 
-            <Output PropertyName="UserAppManifest"
-                    TaskParameter="UserAppManifest" />
-        </GenerateWasmSplashAssets_v0>
+			<Output PropertyName="UserAppManifest"
+					TaskParameter="UserAppManifest"/>
+		</GenerateWasmSplashAssets_v0>
 
-        <!-- Cache the $(UserAppManifest) value to be used on incremental builds-->
+		<!-- Cache the $(UserAppManifest) value to be used on incremental builds-->
 		<WriteLinesToFile
-            File="$(_UnoManifestStampFile)"
-            Lines="$(UserAppManifest)"
-            Overwrite="true"
-            WriteOnlyWhenDifferent="true" />
+				File="$(_UnoManifestStampFile)"
+				Lines="$(UserAppManifest)"
+				Overwrite="true"
+				WriteOnlyWhenDifferent="true"/>
 
-        <!-- Wasm -->
-		<ReadLinesFromFile 
-            File="$(_UnoManifestStampFile)"
-            Condition="$(_UnoResizetizerIsWasmApp) == 'True' And '$(UserAppManifest)' == ''">
-                <Output TaskParameter="Lines" PropertyName="UserAppManifest" />
-        </ReadLinesFromFile>
+		<!-- Wasm -->
+		<ReadLinesFromFile
+				File="$(_UnoManifestStampFile)"
+				Condition="$(_UnoResizetizerIsWasmApp) == 'True' And '$(UserAppManifest)' == ''">
+			<Output TaskParameter="Lines" PropertyName="UserAppManifest"/>
+		</ReadLinesFromFile>
 
-        <ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' And $(UserAppManifest) != ''">
-            <EmbeddedResource Remove="$(UserAppManifest)" />
-            <EmbeddedResource Include="$(_UnoIntermediateAppManifestWasm)"
-                            Link="$(UserAppManifest)"/>
-        </ItemGroup>
-    </Target>
-    
-    <Target Name="ProcessUnoSplashScreens" />
+		<ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' And $(UserAppManifest) != ''">
+			<EmbeddedResource Remove="$(UserAppManifest)"/>
+			<EmbeddedResource Include="$(_UnoIntermediateAppManifestWasm)"
+							  Link="$(UserAppManifest)"/>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="ProcessUnoSplashScreens"/>
 
 	<Target
-		Name="ProcessResizedImagesWasm_v0"
-		AfterTargets="ProcessResizedImages_v0"
-		DependsOnTargets="ProcessResizedImages_v0"
-		Condition="'$(DesignTimeBuild)' != 'true'">
+			Name="ProcessResizedImagesWasm_v0"
+			AfterTargets="ProcessResizedImages_v0"
+			DependsOnTargets="ProcessResizedImages_v0"
+			Condition="'$(DesignTimeBuild)' != 'true'">
 
-        <!-- Wasm -->
+		<!-- Wasm -->
 		<ItemGroup>
 			<Content Include="@(_UnoResizetizerCollectedImages->FullPath())"
-					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)" >
+					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)">
 			</Content>
 
 			<Content Include="@(_UnoResizetizerCollectedAppIcons->FullPath())"
@@ -60,16 +60,16 @@
 					 UnoDeploy="Root"
 					 Link="%(_UnoResizetizerCollectedAppIcons.RecursiveDir)%(_UnoResizetizerCollectedAppIcons.Filename)%(_UnoResizetizerCollectedAppIcons.Extension)"/>
 
-			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
+			<FileWrites Include="@(_UnoResizetizerCollectedImages)"/>
 		</ItemGroup>
 
 		<ItemGroup Condition="'$(UnoResizetizerPwaManifest)' != ''">
-			<Content Remove="$(WasmPWAManifestFile)" />
+			<Content Remove="$(WasmPWAManifestFile)"/>
 			<Content Include="$(UnoResizetizerPwaManifest)"
 					 CopyToOutputDirectory="PreserveNewest"
-					 ExcludeFromSingleFile ="True"
-					 CopyToPublishDirectory ="PreserveNewest"
-					 Link="$(WasmPWAManifestFile)" />
+					 ExcludeFromSingleFile="True"
+					 CopyToPublishDirectory="PreserveNewest"
+					 Link="$(WasmPWAManifestFile)"/>
 		</ItemGroup>
-    </Target>
+	</Target>
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.wasm.targets
+++ b/src/.nuspec/Uno.Resizetizer.wasm.targets
@@ -7,7 +7,6 @@
 
         <!--Wasm-->
 		<GenerateWasmSplashAssets_v0
-            Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
             IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
             EmbeddedResources="@(EmbeddedResource)"
             UnoSplashScreen="@(UnoSplashScreen)"
@@ -19,7 +18,6 @@
 
         <!-- Cache the $(UserAppManifest) value to be used on incremental builds-->
 		<WriteLinesToFile
-            Condition="$(_UnoResizetizerIsWasmApp) == 'True'"
             File="$(_UnoManifestStampFile)"
             Lines="$(UserAppManifest)"
             Overwrite="true"
@@ -48,7 +46,7 @@
 		Condition="'$(DesignTimeBuild)' != 'true'">
 
         <!-- Wasm -->
-		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'">
+		<ItemGroup>
 			<Content Include="@(_UnoResizetizerCollectedImages->FullPath())"
 					 Link="%(_UnoResizetizerCollectedImages.RecursiveDir)%(_UnoResizetizerCollectedImages.Filename)%(_UnoResizetizerCollectedImages.Extension)" >
 			</Content>
@@ -65,7 +63,7 @@
 			<FileWrites Include="@(_UnoResizetizerCollectedImages)" />
 		</ItemGroup>
 
-		<ItemGroup Condition="'$(_UnoResizetizerIsWasmApp)' == 'True' And '$(UnoResizetizerPwaManifest)' != ''">
+		<ItemGroup Condition="'$(UnoResizetizerPwaManifest)' != ''">
 			<Content Remove="$(WasmPWAManifestFile)" />
 			<Content Include="$(UnoResizetizerPwaManifest)"
 					 CopyToOutputDirectory="PreserveNewest"

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -1,7 +1,7 @@
 <Project>
 
     <Target
-        Name="GenerateUnoSplasWindowsSkia"
+        Name="GenerateUnoSplashWindowsSkia"
         AfterTargets="GenerateUnoSplashScreens"
         DependsOnTargets="GenerateUnoSplashScreens"
         Condition="'$(DesignTimeBuild)' != 'True'">
@@ -18,8 +18,8 @@
     </Target>
 
     <Target Name="ProcessUnoSplashScreens"
-            AfterTargets="GenerateUnoSplasWindowsSkia"
-            DependsOnTargets="GenerateUnoSplasWindowsSkia"
+            AfterTargets="GenerateUnoSplashWindowsSkia"
+            DependsOnTargets="GenerateUnoSplashWindowsSkia"
 			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
 
         <ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -1,0 +1,102 @@
+<Project>
+
+    <Target
+        Name="GenerateUnoSplasWindowsSkia"
+        AfterTargets="GenerateUnoSplashScreens"
+        DependsOnTargets="GenerateUnoSplashScreens"
+        Condition="'$(DesignTimeBuild)' != 'True'">
+        <!-- UWP / WinUI -->
+		<ItemGroup
+            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+                <UnoWindowsSplash Include="@(UnoSplashScreen)" Link="" />
+        </ItemGroup>
+        <GenerateSplashAssets_v0
+            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
+            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+            UnoSplashScreen="@(UnoWindowsSplash)"
+        />
+    </Target>
+
+    <Target Name="ProcessUnoSplashScreens"
+            AfterTargets="GenerateUnoSplasWindowsSkia"
+            DependsOnTargets="GenerateUnoSplasWindowsSkia"
+			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
+
+        <ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
+			<_UnoSplashAssets Include="$(_UnoIntermediateSplashScreen)**\*" />
+			<ContentWithTargetPath Include="@(_UnoSplashAssets)">
+				<TargetPath>%(_UnoSplashAssets.Filename)%(_UnoSplashAssets.Extension)</TargetPath>
+			</ContentWithTargetPath>
+			<FileWrites Include="@(_UnoSplashAssets)" />
+		</ItemGroup>
+    </Target>
+
+    <!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly
+	depends on "_ValidatePresenceOfAppxManifestItems" and we need to get in before then. -->
+	<Target Name="_UnoValidatePresenceOfAppxManifestItemsBeforeTarget"
+            BeforeTargets="_ValidatePresenceOfAppxManifestItems"
+            DependsOnTargets="UnoGeneratePackageAppxManifest"
+            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
+            <Target Name="UnoGeneratePackageAppxManifest"
+            Condition="('$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
+            DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
+            BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
+            Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
+            Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
+    
+    
+            <PropertyGroup>
+                <_UnoWindowsApplicationId
+                    Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">
+                    $(ApplicationIdGuid)</_UnoWindowsApplicationId>
+                <_UnoWindowsApplicationId
+                    Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">
+                    $(ApplicationId)</_UnoWindowsApplicationId>
+            </PropertyGroup>
+    
+            <GeneratePackageAppxManifest_v0
+                IntermediateOutputPath="$(_UnoIntermediateManifest)"
+                AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
+                GeneratedFilename="Package.appxmanifest"
+                ApplicationId="$(_UnoWindowsApplicationId)"
+                ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
+                ApplicationVersion="$(ApplicationVersion)"
+                ApplicationTitle="$(ApplicationTitle)"
+                AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
+                SplashScreen="@(UnoSplashScreen)" />
+    
+            <!-- replace user manifest -->
+            <ItemGroup Condition="'@(AppxManifest)' != ''">
+                <AppxManifest Remove="@(AppxManifest)" />
+                <AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
+            </ItemGroup>
+            <ItemGroup Condition="'@(_SkiaManifest)' != '' ">
+                <AppxManifest Remove="@(AppxManifest)" />
+                <AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
+    
+                <!--If
+                there's no LogicalName, we use the default name-->
+                <EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
+                    Link="%(_SkiaManifest.Link)"
+                    LogicalName="Package.appxmanifest"
+                    Condition="%(_SkiaManifest.LogicalName) == '' " />
+    
+                <EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
+                    Link="%(_SkiaManifest.Link)"
+                    LogicalName="%(_SkiaManifest.LogicalName)"
+                    Condition="%(_SkiaManifest.LogicalName) != '' " />
+    
+            </ItemGroup>
+            <ItemGroup Condition="'@(_UnoAppxManifest)' != ''">
+                <_UnoAppxManifest Remove="@(_UnoAppxManifest)" />
+                <_UnoAppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
+            </ItemGroup>
+    
+            <MakeDir Directories="$(IntermediateOutputPath)" />
+            <!-- Stamp file for Outputs -->
+            <Touch Files="$(_UnoManifestStampFile)" AlwaysCreate="True" />
+            <ItemGroup>
+                <FileWrites Include="$(_UnoManifestStampFile)" />
+            </ItemGroup>
+        </Target>
+</Project>

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -1,102 +1,104 @@
 <Project>
 
-    <Target
-        Name="GenerateUnoSplashWindowsSkia"
-        AfterTargets="GenerateUnoSplashScreens"
-        DependsOnTargets="GenerateUnoSplashScreens"
-        Condition="'$(DesignTimeBuild)' != 'True'">
-        <!-- UWP / WinUI -->
+	<Target
+			Name="GenerateUnoSplashWindowsSkia"
+			AfterTargets="GenerateUnoSplashScreens"
+			DependsOnTargets="GenerateUnoSplashScreens"
+			Condition="'$(DesignTimeBuild)' != 'True'">
+		<!-- UWP / WinUI -->
 		<ItemGroup
-            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
-                <UnoWindowsSplash Include="@(UnoSplashScreen)" Link="" />
-        </ItemGroup>
-        <GenerateSplashAssets_v0
-            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
-            IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
-            UnoSplashScreen="@(UnoWindowsSplash)"
-        />
-    </Target>
+				Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+			<UnoWindowsSplash Include="@(UnoSplashScreen)" Link=""/>
+		</ItemGroup>
+		<GenerateSplashAssets_v0
+				Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
+				IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
+				UnoSplashScreen="@(UnoWindowsSplash)"
+		/>
+	</Target>
 
-    <Target Name="ProcessUnoSplashScreens"
-            AfterTargets="GenerateUnoSplashWindowsSkia"
-            DependsOnTargets="GenerateUnoSplashWindowsSkia"
+	<Target Name="ProcessUnoSplashScreens"
+			AfterTargets="GenerateUnoSplashWindowsSkia"
+			DependsOnTargets="GenerateUnoSplashWindowsSkia"
 			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
 
-        <ItemGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
-			<_UnoSplashAssets Include="$(_UnoIntermediateSplashScreen)**\*" />
+		<ItemGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
+			<_UnoSplashAssets Include="$(_UnoIntermediateSplashScreen)**\*"/>
 			<ContentWithTargetPath Include="@(_UnoSplashAssets)">
 				<TargetPath>%(_UnoSplashAssets.Filename)%(_UnoSplashAssets.Extension)</TargetPath>
 			</ContentWithTargetPath>
-			<FileWrites Include="@(_UnoSplashAssets)" />
+			<FileWrites Include="@(_UnoSplashAssets)"/>
 		</ItemGroup>
-    </Target>
+	</Target>
 
-    <!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly
+	<!-- This is required because the "CalculateAppxGenerateProjectPriEnabled" target explicitly
 	depends on "_ValidatePresenceOfAppxManifestItems" and we need to get in before then. -->
 	<Target Name="_UnoValidatePresenceOfAppxManifestItemsBeforeTarget"
-            BeforeTargets="_ValidatePresenceOfAppxManifestItems"
-            DependsOnTargets="UnoGeneratePackageAppxManifest"
-            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
-            <Target Name="UnoGeneratePackageAppxManifest"
-            Condition="('$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
-            DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
-            BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
-            Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
-            Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
-    
-    
-            <PropertyGroup>
-                <_UnoWindowsApplicationId
-                    Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">
-                    $(ApplicationIdGuid)</_UnoWindowsApplicationId>
-                <_UnoWindowsApplicationId
-                    Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">
-                    $(ApplicationId)</_UnoWindowsApplicationId>
-            </PropertyGroup>
-    
-            <GeneratePackageAppxManifest_v0
-                IntermediateOutputPath="$(_UnoIntermediateManifest)"
-                AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
-                GeneratedFilename="Package.appxmanifest"
-                ApplicationId="$(_UnoWindowsApplicationId)"
-                ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
-                ApplicationVersion="$(ApplicationVersion)"
-                ApplicationTitle="$(ApplicationTitle)"
-                AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
-                SplashScreen="@(UnoSplashScreen)" />
-    
-            <!-- replace user manifest -->
-            <ItemGroup Condition="'@(AppxManifest)' != ''">
-                <AppxManifest Remove="@(AppxManifest)" />
-                <AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-            </ItemGroup>
-            <ItemGroup Condition="'@(_SkiaManifest)' != '' ">
-                <AppxManifest Remove="@(AppxManifest)" />
-                <AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-    
-                <!--If
-                there's no LogicalName, we use the default name-->
-                <EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-                    Link="%(_SkiaManifest.Link)"
-                    LogicalName="Package.appxmanifest"
-                    Condition="%(_SkiaManifest.LogicalName) == '' " />
-    
-                <EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
-                    Link="%(_SkiaManifest.Link)"
-                    LogicalName="%(_SkiaManifest.LogicalName)"
-                    Condition="%(_SkiaManifest.LogicalName) != '' " />
-    
-            </ItemGroup>
-            <ItemGroup Condition="'@(_UnoAppxManifest)' != ''">
-                <_UnoAppxManifest Remove="@(_UnoAppxManifest)" />
-                <_UnoAppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest" />
-            </ItemGroup>
-    
-            <MakeDir Directories="$(IntermediateOutputPath)" />
-            <!-- Stamp file for Outputs -->
-            <Touch Files="$(_UnoManifestStampFile)" AlwaysCreate="True" />
-            <ItemGroup>
-                <FileWrites Include="$(_UnoManifestStampFile)" />
-            </ItemGroup>
-        </Target>
+			BeforeTargets="_ValidatePresenceOfAppxManifestItems"
+			DependsOnTargets="UnoGeneratePackageAppxManifest"
+			Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'"/>
+	<Target Name="UnoGeneratePackageAppxManifest"
+			Condition="('$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
+			DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
+			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
+			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
+			Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
+
+
+		<PropertyGroup>
+			<_UnoWindowsApplicationId
+					Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">
+				$(ApplicationIdGuid)
+			</_UnoWindowsApplicationId>
+			<_UnoWindowsApplicationId
+					Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">
+				$(ApplicationId)
+			</_UnoWindowsApplicationId>
+		</PropertyGroup>
+
+		<GeneratePackageAppxManifest_v0
+				IntermediateOutputPath="$(_UnoIntermediateManifest)"
+				AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
+				GeneratedFilename="Package.appxmanifest"
+				ApplicationId="$(_UnoWindowsApplicationId)"
+				ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
+				ApplicationVersion="$(ApplicationVersion)"
+				ApplicationTitle="$(ApplicationTitle)"
+				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
+				SplashScreen="@(UnoSplashScreen)"/>
+
+		<!-- replace user manifest -->
+		<ItemGroup Condition="'@(AppxManifest)' != ''">
+			<AppxManifest Remove="@(AppxManifest)"/>
+			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest"/>
+		</ItemGroup>
+		<ItemGroup Condition="'@(_SkiaManifest)' != '' ">
+			<AppxManifest Remove="@(AppxManifest)"/>
+			<AppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest"/>
+
+			<!--If
+			there's no LogicalName, we use the default name-->
+			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
+							  Link="%(_SkiaManifest.Link)"
+							  LogicalName="Package.appxmanifest"
+							  Condition="%(_SkiaManifest.LogicalName) == '' "/>
+
+			<EmbeddedResource Include="$(_UnoIntermediateManifest)Package.appxmanifest"
+							  Link="%(_SkiaManifest.Link)"
+							  LogicalName="%(_SkiaManifest.LogicalName)"
+							  Condition="%(_SkiaManifest.LogicalName) != '' "/>
+
+		</ItemGroup>
+		<ItemGroup Condition="'@(_UnoAppxManifest)' != ''">
+			<_UnoAppxManifest Remove="@(_UnoAppxManifest)"/>
+			<_UnoAppxManifest Include="$(_UnoIntermediateManifest)Package.appxmanifest"/>
+		</ItemGroup>
+
+		<MakeDir Directories="$(IntermediateOutputPath)"/>
+		<!-- Stamp file for Outputs -->
+		<Touch Files="$(_UnoManifestStampFile)" AlwaysCreate="True"/>
+		<ItemGroup>
+			<FileWrites Include="$(_UnoManifestStampFile)"/>
+		</ItemGroup>
+	</Target>
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -7,11 +7,11 @@
         Condition="'$(DesignTimeBuild)' != 'True'">
         <!-- UWP / WinUI -->
 		<ItemGroup
-            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
                 <UnoWindowsSplash Include="@(UnoSplashScreen)" Link="" />
         </ItemGroup>
         <GenerateSplashAssets_v0
-            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
+            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'"
             IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"
             UnoSplashScreen="@(UnoWindowsSplash)"
         />
@@ -22,7 +22,7 @@
             DependsOnTargets="GenerateUnoSplashWindowsSkia"
 			Condition="'@(UnoSplashScreen)' != '' And '$(DesignTimeBuild)' != 'true'">
 
-        <ItemGroup Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
+        <ItemGroup Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'">
 			<_UnoSplashAssets Include="$(_UnoIntermediateSplashScreen)**\*" />
 			<ContentWithTargetPath Include="@(_UnoSplashAssets)">
 				<TargetPath>%(_UnoSplashAssets.Filename)%(_UnoSplashAssets.Extension)</TargetPath>
@@ -36,9 +36,9 @@
 	<Target Name="_UnoValidatePresenceOfAppxManifestItemsBeforeTarget"
             BeforeTargets="_ValidatePresenceOfAppxManifestItems"
             DependsOnTargets="UnoGeneratePackageAppxManifest"
-            Condition="'$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
+            Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'" />
             <Target Name="UnoGeneratePackageAppxManifest"
-            Condition="('$(_UnoResizetizerIsUWPApp)' == 'True' Or '$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
+            Condition="('$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
             DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
             BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
             Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"


### PR DESCRIPTION
This PR brings back the idea to refactor the platform code into separate files in order to make it easier to maintain. All the samples are running just like the `main` branch, so this doesn't change any behavior of the Resizetizer.

Closes: #134 