### PR TITLE
fix: Add the ability to disable Windows extensions generation

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -510,7 +510,7 @@
 	</Target>
 
 	<Target Name="_AddResizetizerWindowIconExtensions"
-			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True' and '$(UnoResizetizerDisableWindowIconExtensions)'==''"
+			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True' and '$(UnoResizetizerDisableWindowIconExtensions)'!='true'"
 			AfterTargets="_GenerateWindowUnoIconExtension"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile">
 		<ItemGroup Condition="Exists('@(_WindowIconExtension->FullPath())')">

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -510,7 +510,7 @@
 	</Target>
 
 	<Target Name="_AddResizetizerWindowIconExtensions"
-			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True'"
+			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True' and '$(UnoResizetizerDisableWindowIconExtensions)'==''"
 			AfterTargets="_GenerateWindowUnoIconExtension"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile">
 		<ItemGroup Condition="Exists('@(_WindowIconExtension->FullPath())')">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adds the ability to disable the generated windows extensions. Used when building with UWP inside the uno solution.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
