### PR TITLE
Revert "♻️ bump packages versions"

### DIFF
--- a/src/Resizetizer/Directory.build.props
+++ b/src/Resizetizer/Directory.build.props
@@ -6,10 +6,10 @@
        - Feed URI in the nuget.config
        - Native assets build and sha
     -->
-		<_SkiaSharpVersion>2.88.5</_SkiaSharpVersion>
-		<_HarfBuzzSharpVersion>2.8.2.5</_HarfBuzzSharpVersion>
+		<_SkiaSharpVersion>2.88.3</_SkiaSharpVersion>
+		<_HarfBuzzSharpVersion>2.8.2.3</_HarfBuzzSharpVersion>
 		<!-- <_SkiaSharpNativeAssetsVersion>0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483</_SkiaSharpNativeAssetsVersion> -->
-		<SvgSkiaPackageVersion>1.0.0.2</SvgSkiaPackageVersion>
+		<SvgSkiaPackageVersion>0.5.18</SvgSkiaPackageVersion>
 		<FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts unoplatform/uno.resizetizer#173

The update is causing issues: https://github.com/unoplatform/uno/pull/13878