### PR TITLE
ci: Add validation using `dotnet`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Validate sample app (mobile) - dotnet
       run: |
-        dotnet /bl:.\logs\samples-dotnet.binlog samples\NewTemplate\Resizetizer.Extensions.Sample.Mobile\Resizetizer.Extensions.Sample.Mobile.csproj /p:AotAssemblies=false /p:WasmShellILLinkerEnabled=false
+        dotnet build samples\NewTemplate\Resizetizer.Extensions.Sample.Mobile\Resizetizer.Extensions.Sample.Mobile.csproj --no-incremental -bl:.\logs\samples-dotnet.binlog -p:AotAssemblies=false
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,14 @@ jobs:
       run: |
         dotnet test src/Resizetizer/test/UnitTests/Resizetizer.UnitTests.csproj
 
-    - name: Validate sample app
+    - name: Validate sample app - MSBuild
       run: |
         $msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
-        & $msbuild /r /bl:.\logs\samples.binlog samples\NewTemplate\Resizetizer.Extensions.Sample.sln /p:AotAssemblies=false /p:WasmShellILLinkerEnabled=false
+        & $msbuild /r /bl:.\logs\samples-msbuild.binlog samples\NewTemplate\Resizetizer.Extensions.Sample.sln /p:AotAssemblies=false /p:WasmShellILLinkerEnabled=false
+
+    - name: Validate sample app (mobile) - dotnet
+      run: |
+        dotnet /bl:.\logs\samples-dotnet.binlog samples\NewTemplate\Resizetizer.Extensions.Sample.Mobile\Resizetizer.Extensions.Sample.Mobile.csproj /p:AotAssemblies=false /p:WasmShellILLinkerEnabled=false
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Fixes: #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
