### PR TITLE
fix: Use `TaskHostFactory` to run tasks in isolated environment

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -14,27 +14,33 @@
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.ResizetizeImages_v0"/>
+			TaskName="Uno.Resizetizer.ResizetizeImages_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.DetectInvalidResourceOutputFilenamesTask_v0"/>
+			TaskName="Uno.Resizetizer.DetectInvalidResourceOutputFilenamesTask_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.CreatePartialInfoPlistTask_v0"/>
+			TaskName="Uno.Resizetizer.CreatePartialInfoPlistTask_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.GenerateSplashAndroidResources_v0"/>
+			TaskName="Uno.Resizetizer.GenerateSplashAndroidResources_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.GenerateSplashStoryboard_v0"/>
+			TaskName="Uno.Resizetizer.GenerateSplashStoryboard_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.GenerateSplashAssets_v0"/>
+			TaskName="Uno.Resizetizer.GenerateSplashAssets_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
@@ -42,15 +48,18 @@
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.GeneratePackageAppxManifest_v0"/>
+			TaskName="Uno.Resizetizer.GeneratePackageAppxManifest_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.GenerateWasmSplashAssets_v0"/>
+			TaskName="Uno.Resizetizer.GenerateWasmSplashAssets_v0"
+			TaskFactory="TaskHostFactory" />
 
 	<UsingTask
 			AssemblyFile="$(_UnoResizetizerTaskAssemblyName)"
-			TaskName="Uno.Resizetizer.WindowIconGeneratorTask_V0"/>
+			TaskName="Uno.Resizetizer.WindowIconGeneratorTask_V0"
+			TaskFactory="TaskHostFactory" />
 
 	<PropertyGroup>
 		<CleanDependsOn>


### PR DESCRIPTION
Fixes: #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Failures similar to:

```
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018: The "GenerateSplashAndroidResources_8fdbe6f9ea0dffe54098cbb6a8c2002d965d1a7a" task failed unexpectedly. [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018: System.MissingMethodException: Method not found: 'SkiaSharp.SKTextBlob SkiaSharp.SKTextBlob.CreatePositioned(System.String, SkiaSharp.SKFont, System.ReadOnlySpan`1<SkiaSharp.SKPoint>)'. [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Svg.Skia.SkiaModel.Draw(CanvasCommand canvasCommand, SKCanvas skCanvas) [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Svg.Skia.SkiaModel.Draw(SKPicture picture, SKCanvas skCanvas) in /_/src/Svg.Skia/SkiaModel.cs:line 1183 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Svg.Skia.SkiaModel.ToSKPicture(SKPicture picture) in /_/src/Svg.Skia/SkiaModel.cs:line 1054 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Svg.Skia.SKSvg.Load(String path) in /_/src/Svg.Skia/SKSvg.Model.cs:line 82 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Uno.Resizetizer.SkiaSharpSvgTools..ctor(String filename, Nullable`1 baseSize, Nullable`1 backgroundColor, Nullable`1 tintColor, ILogger logger) in D:\a\uno.resizetizer\uno.resizetizer\src\Resizetizer\src\SkiaSharpSvgTools.cs:line 24 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Uno.Resizetizer.SkiaSharpTools.Create(Boolean isVector, String filename, Nullable`1 baseSize, Nullable`1 backgroundColor, Nullable`1 tintColor, ILogger logger) in D:\a\uno.resizetizer\uno.resizetizer\src\Resizetizer\src\SkiaSharpTools.cs:line 11 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Uno.Resizetizer.GenerateSplashAndroidResources_8fdbe6f9ea0dffe54098cbb6a8c2002d965d1a7a.Execute() in D:\a\uno.resizetizer\uno.resizetizer\src\Resizetizer\src\GenerateSplashAndroidResources.cs:line 30 [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]
C:\Users\VssAdministrator\.nuget\packages\uno.resizetizer\1.2.0-dev.68\build\Uno.Resizetizer.android.targets(8,3): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [D:\a\1\s\UnoApp1\UnoApp1.Mobile\UnoApp1.Mobile.csproj::TargetFramework=net7.0-android]

```

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Hopefully, get that all fixed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
