### PR TITLE
♻️Bump versions to avoid method missmatch

### DIFF
--- a/src/Resizetizer/Directory.build.props
+++ b/src/Resizetizer/Directory.build.props
@@ -6,10 +6,10 @@
        - Feed URI in the nuget.config
        - Native assets build and sha
     -->
-		<_SkiaSharpVersion>2.88.5</_SkiaSharpVersion>
-		<_HarfBuzzSharpVersion>2.8.2.5</_HarfBuzzSharpVersion>
+		<_SkiaSharpVersion>2.88.6</_SkiaSharpVersion>
+		<_HarfBuzzSharpVersion>7.3.0</_HarfBuzzSharpVersion>
 		<!-- <_SkiaSharpNativeAssetsVersion>0.0.0-commit.193b587552cb0ed39372a049d7e6c692db98c267.483</_SkiaSharpNativeAssetsVersion> -->
-		<SvgSkiaPackageVersion>1.0.0.2</SvgSkiaPackageVersion>
+		<SvgSkiaPackageVersion>1.0.0.3</SvgSkiaPackageVersion>
 		<FizzlerPackageVersion>1.3.0</FizzlerPackageVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Resizetizer/src/ResizetizerPackages.projitems
+++ b/src/Resizetizer/src/ResizetizerPackages.projitems
@@ -13,7 +13,7 @@
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="$(_SkiaSharpVersion)" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="ExCSS" Version="4.1.4.0"  GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="ExCSS" Version="4.2.3"  GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Skia" Version="$(SvgSkiaPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Custom" Version="$(SvgSkiaPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="Svg.Model" Version="$(SvgSkiaPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
@@ -21,8 +21,8 @@
     <PackageReference Include="Fizzler" Version="$(FizzlerPackageVersion)" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.5" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Buffers" Version="4.5.1" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" GeneratePathProperty="true" PrivateAssets="all" />


### PR DESCRIPTION
There's no issue opened for this one, but some other Uno apps are failing on Resizetizer, so bumping more packages should fix it. Some of these packages are released this week, so that could help.