### PR TITLE
[🔥HotFix] Fixed the git hash used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Adjust msbuild task name
       run: |
         cd src
-        gci -r -File -Include *.cs,*.targets,*.props,*.csproj | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{ steps.gitversion.outputs.VersionSha }}" }  | set-content $a }
+        gci -r -File -Include *.cs,*.targets,*.props,*.csproj | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{steps.gitversion.outputs.sha}}" }  | set-content $a }
 
     - run: |
           & dotnet tool update --global uno.check --version ${{ env.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Adjust msbuild task name
       run: |
         cd src
-        gci -r -File -Include *.cs,*.targets,*.props,*.csproj | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{ steps.gitversion.outputs.VersionSourceSha }}" }  | set-content $a }
+        gci -r -File -Include *.cs,*.targets,*.props,*.csproj | foreach-object { $a = $_.fullname; ( get-content $a ) | foreach-object { $_ -replace "v0","${{ steps.gitversion.outputs.VersionSha }}" }  | set-content $a }
 
     - run: |
           & dotnet tool update --global uno.check --version ${{ env.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
So, you may notice that we decore some `MSBuild` tasks with the `v_0` suffix, this is intended to be changed, during the build, to the commit hash, in order to avoid confusion with different Uno.Resizetizer packages in the nuget cache. This appears in the first place when you have the `Uno.Resizetizer 1.2.0-dev.39`  and update to `1.2.0-dev.76`, will break the build, because there's a breaking change on the task, and the compiler will try to use the old version.

The issue was that our CI was using the wrong variable to replace the `v_0` and now using the correct one should fix it and make the world happy again. The good news is the git keeps generating different hashes for commits, so no apocalypse so far.