### PR TITLE
Fixed validation logic to check if UnoSplashScreen == UnoIcon

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -284,11 +284,11 @@
 				Text="The UnoSplashScreen.Link property will be ignored."/>
 		
 		<Error
-				Condition="'@(UnoSplashScreen)' == '@(UnoIcon)'"
+				Condition="'@(UnoSplashScreen)' != '' And '@(UnoSplashScreen)' == '@(UnoIcon)'"
 				Text="The value of UnoSplashScreen and UnoIcon cannot be the same."/>
 
 		<Error
-				Condition="'@(UnoSplashScreen)' == '%(UnoIcon.ForegroundFile)'"
+				Condition="'@(UnoSplashScreen)' != '' And '@(UnoSplashScreen)' == '%(UnoIcon.ForegroundFile)'"
 				Text="The value of UnoSplashScreen and UnoIcon.ForegroundFile cannot be the same."/>
 	</Target>
 


### PR DESCRIPTION
This issue was reported by @agneszitte on teams.

If there's no UnoSplashScreen and UnoIcon, the validation will say that `UnoIcon == UnoSplashScreen` and we that validation shouldn't run if one of those are empty.

@agneszitte can you try the generated package and confirm if it fixes the issue?