### PR TITLE
Fix the appxmanifest generation

### DIFF
--- a/samples/NewTemplate/Resizetizer.Extensions.Sample.Skia.Gtk/Resizetizer.Extensions.Sample.Skia.Gtk.csproj
+++ b/samples/NewTemplate/Resizetizer.Extensions.Sample.Skia.Gtk/Resizetizer.Extensions.Sample.Skia.Gtk.csproj
@@ -30,7 +30,7 @@
 			<_ResizetizerManifestPath>$(_UnoIntermediateManifest)Package.appxmanifest</_ResizetizerManifestPath>
 			<_ResizetizerSplashScreenPath>$(_UnoIntermediateImages)splash_screen.scale-125.png</_ResizetizerSplashScreenPath>
 			<_ResizetizerAppIconPath>$(_UnoIntermediateImages)iconapp.ico</_ResizetizerAppIconPath>
-			<_ResizetizerAppIconImagesPath>$(_UnoIntermediateImages)iconapp.png</_ResizetizerAppIconImagesPath>
+			<_ResizetizerAppIconImagesPath>$(_UnoIntermediateImages)Icons\iconappLogo.scale-100.png</_ResizetizerAppIconImagesPath>
 		</PropertyGroup>
 		<Message Text="Validating local assets at '$(_ResizetizerIntermediateOutputRoot)'" Importance="high" />
 		<Error Condition="!Exists('$(_ResizetizerManifestPath)')" Text="Manifest file wasn't created." />

--- a/samples/NewTemplate/Resizetizer.Extensions.Sample.Skia.WPF/Resizetizer.Extensions.Sample.Skia.WPF.csproj
+++ b/samples/NewTemplate/Resizetizer.Extensions.Sample.Skia.WPF/Resizetizer.Extensions.Sample.Skia.WPF.csproj
@@ -43,7 +43,7 @@
 		<PropertyGroup>
 			<_ResizetizerSplashScreenPath>$(_UnoIntermediateImages)splash_screen.scale-125.png</_ResizetizerSplashScreenPath>
 			<_ResizetizerAppIconPath>$(_UnoIntermediateImages)iconapp.ico</_ResizetizerAppIconPath>
-			<_ResizetizerAppIconImagesPath>$(_UnoIntermediateImages)iconapp.png</_ResizetizerAppIconImagesPath>
+			<_ResizetizerAppIconImagesPath>$(_UnoIntermediateImages)Icons\iconappLogo.scale-100.png</_ResizetizerAppIconImagesPath>
 		</PropertyGroup>
 		<Message Text="Validating local assets at '$(_ResizetizerIntermediateOutputRoot)'" Importance="high" />
 		<Error Condition="!Exists('$(_ResizetizerSplashScreenPath)')" Text="SplashScreen file wasn't created." />

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -3,8 +3,7 @@
 	<Target 
 		Name="UpdatePathOfUnoIcon"
 		BeforeTargets="UnoResizetizeCollectItems"
-		DependsOnTargets="ValidateAvailableItems"
-		Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True'">
+		DependsOnTargets="ValidateAvailableItems">
 		
 		<AssignLinkMetadata Items="@(UnoIcon)">
 			<Output TaskParameter="OutputItems" ItemName="_UnoIconLinked"/>

--- a/src/Resizetizer/src/DpiPath.cs
+++ b/src/Resizetizer/src/DpiPath.cs
@@ -230,16 +230,6 @@ namespace Uno.Resizetizer
 				LargeTile).ToArray();
 		}
 
-		public static class Wpf
-		{
-			public static DpiPath[] AppIcon
-				=> new[]
-				{
-					new DpiPath("", 4.0m),
-				};
-		}
-
-
 		public static class Wasm
 		{
 			public static DpiPath[] AppIcon => new[]
@@ -276,10 +266,8 @@ namespace Uno.Resizetizer
 					break;
 				case "uwp":
 				case "windows":
-					result = DpiPath.Windows.AppIcon;
-					break;
 				case "wpf":
-					result = DpiPath.Wpf.AppIcon;
+					result = DpiPath.Windows.AppIcon;
 					break;
 				case "wasm":
 					result = DpiPath.Wasm.AppIcon;


### PR DESCRIPTION
Fixes: #199

From the original implementation, Skia Targets generates just one icon image, in terms of usability that was enough, but since Skia Targets uses the `appxmanifest` this PR updates those targets to generate the same assets as winUI and match with the generated `appxmanifest`.

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
