### PR TITLE
fix: Set AppWindow.Title to DisplayName

### DIFF
--- a/src/Resizetizer/src/WindowIconGeneratorTask.cs
+++ b/src/Resizetizer/src/WindowIconGeneratorTask.cs
@@ -68,6 +68,8 @@ namespace Uno.Resizetizer
 			global::Microsoft.UI.Windowing.AppWindow appWindow =
 				global::Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
 			appWindow.SetIcon(""{iconName}.ico"");
+
+			appWindow.Title = window.Title;
 #endif
 		}}
 	}}

--- a/src/Resizetizer/src/WindowIconGeneratorTask.cs
+++ b/src/Resizetizer/src/WindowIconGeneratorTask.cs
@@ -67,9 +67,12 @@ namespace Uno.Resizetizer
 			// Lastly, retrieve the AppWindow for the current (XAML) WinUI 3 window.
 			global::Microsoft.UI.Windowing.AppWindow appWindow =
 				global::Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
-			appWindow.SetIcon(""{iconName}.ico"");
 
-			appWindow.Title = window.Title;
+			if (appWindow != null)
+			{{
+				appWindow.SetIcon(""{iconName}.ico"");
+				appWindow.Title = AppInfo.Current.DisplayInfo.DisplayName;
+			}}
 #endif
 		}}
 	}}


### PR DESCRIPTION
Fixes: #208 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

**Context:**
On Windows targets, `AppWindow` currently lacks a default value for its `Title` property. 


In our task for generating window icon, we form the code to retrieve an `AppWindow` from the XAML `Window`, using it to conveniently set the generated `ico` file. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Upon retrieval of `AppWindow`, set AppWindow.Title to be the app's `DisplayName`. This value is obtained from the XAML `Window` instance which has a pre-defined `Title` property. (defaulting to `DisplayName`)

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
