### PR TITLE
fix: Set AppWindow.Title to DisplayName

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -509,7 +509,6 @@
 	<Target Name="_GenerateWindowUnoIconExtension"
 			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True'"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile"
-            DependsOnTargets="UnoGeneratePackageAppxManifest"
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -513,7 +513,7 @@
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
 				IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
-                WindowTitle="$(WindowTitle)"
+				WindowTitle="$(WindowTitle)"
 				UnoIcons="@(UnoIcon)">
 			<Output ItemName="GeneratedFile"
 					TaskParameter="GeneratedClass"/>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -513,6 +513,7 @@
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
 				IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
+				WindowTitle="$(ApplicationTitle)"
 				UnoIcons="@(UnoIcon)">
 			<Output ItemName="GeneratedFile"
 					TaskParameter="GeneratedClass"/>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -509,11 +509,12 @@
 	<Target Name="_GenerateWindowUnoIconExtension"
 			Condition="'$(_UnoResizetizerIsCompatibleApp)' == 'True'"
 			BeforeTargets="Build;CoreCompile;XamlPreCompile"
+            DependsOnTargets="UnoGeneratePackageAppxManifest"
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
 		<WindowIconGeneratorTask_v0
 				IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
-				WindowTitle="$(ApplicationTitle)"
+                WindowTitle="$(WindowTitle)"
 				UnoIcons="@(UnoIcon)">
 			<Output ItemName="GeneratedFile"
 					TaskParameter="GeneratedClass"/>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -511,6 +511,11 @@
 			BeforeTargets="Build;CoreCompile;XamlPreCompile"
 			Inputs="@(UnoIcon)"
 			Outputs="@(_WindowIconExtension)">
+
+		<PropertyGroup>
+			<WindowTitle Condition="'$(WindowTitle)' == ''">$(ApplicationTitle)</WindowTitle>
+		</PropertyGroup>
+
 		<WindowIconGeneratorTask_v0
 				IntermediateOutputDirectory="$(_UnoResizetizerIntermediateOutputRoot)"
 				WindowTitle="$(WindowTitle)"

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -52,10 +52,11 @@
 			BeforeTargets="_ValidatePresenceOfAppxManifestItems"
 			DependsOnTargets="UnoGeneratePackageAppxManifest"
 			Condition="'$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True'"/>
+
 	<Target Name="UnoGeneratePackageAppxManifest"
 			Condition="('$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
 			DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
-			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets)"
+			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets);_GenerateWindowUnoIconExtension"
 			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
 			Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
 

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -1,10 +1,10 @@
 <Project>
 
-	<Target 
+	<Target
 		Name="UpdatePathOfUnoIcon"
 		BeforeTargets="UnoResizetizeCollectItems"
 		DependsOnTargets="ValidateAvailableItems">
-		
+
 		<AssignLinkMetadata Items="@(UnoIcon)">
 			<Output TaskParameter="OutputItems" ItemName="_UnoIconLinked"/>
 		</AssignLinkMetadata>
@@ -71,7 +71,7 @@
 			</_UnoWindowsApplicationId>
 		</PropertyGroup>
 
-        <GeneratePackageAppxManifest_v0
+		<GeneratePackageAppxManifest_v0
 				IntermediateOutputPath="$(_UnoIntermediateManifest)"
 				AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
 				GeneratedFilename="Package.appxmanifest"
@@ -82,9 +82,9 @@
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
 				TargetFramework="$(_UnoResizetizerPlatformIdentifier)"
 				SplashScreen="@(UnoSplashScreen)">
-            <Output PropertyName="WindowTitle"
+			<Output PropertyName="WindowTitle"
 					TaskParameter="DisplayName"/>
-        </GeneratePackageAppxManifest_v0>
+		</GeneratePackageAppxManifest_v0>
 
 		<!-- replace user manifest -->
 		<ItemGroup Condition="'@(AppxManifest)' != ''">

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -82,7 +82,7 @@
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
 				TargetFramework="$(_UnoResizetizerPlatformIdentifier)"
 				SplashScreen="@(UnoSplashScreen)">
-            <Output ItemName="WindowTitle"
+            <Output PropertyName="WindowTitle"
 					TaskParameter="DisplayName"/>
         </GeneratePackageAppxManifest_v0>
 

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -71,7 +71,7 @@
 			</_UnoWindowsApplicationId>
 		</PropertyGroup>
 
-		<GeneratePackageAppxManifest_v0
+        <GeneratePackageAppxManifest_v0
 				IntermediateOutputPath="$(_UnoIntermediateManifest)"
 				AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
 				GeneratedFilename="Package.appxmanifest"
@@ -81,7 +81,10 @@
 				ApplicationTitle="$(ApplicationTitle)"
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
 				TargetFramework="$(_UnoResizetizerPlatformIdentifier)"
-				SplashScreen="@(UnoSplashScreen)"/>
+				SplashScreen="@(UnoSplashScreen)">
+            <Output ItemName="WindowTitle"
+					TaskParameter="DisplayName"/>
+        </GeneratePackageAppxManifest_v0>
 
 		<!-- replace user manifest -->
 		<ItemGroup Condition="'@(AppxManifest)' != ''">

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -51,7 +51,7 @@ namespace Uno.Resizetizer
 		public override bool Execute()
 		{
 #if DEBUG_RESIZETIZER
-			System.Diagnostics.Debugger.Launch();
+			//System.Diagnostics.Debugger.Launch();
 #endif
 			try
 			{

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -45,6 +45,9 @@ namespace Uno.Resizetizer
 		[Output]
 		public ITaskItem GeneratedAppxManifest { get; set; } = null!;
 
+		[Output]
+		public string DisplayName { get; private set; } = null!;
+
 		public override bool Execute()
 		{
 #if DEBUG_RESIZETIZER
@@ -143,19 +146,22 @@ namespace Uno.Resizetizer
 					appx.Root.Add(properties);
 				}
 
-				// <DisplayName>
-				if (!string.IsNullOrEmpty(ApplicationTitle))
-				{
-					var xname = xmlns + "DisplayName";
-					var xelem = properties.Element(xname);
-					if (xelem == null || string.IsNullOrEmpty(xelem.Value) || xelem.Value == DefaultPlaceholder)
-					{
-						properties.SetElementValue(xname, ApplicationTitle);
-					}
-				}
+                // <DisplayName>
+                var xDisplayName = xmlns + "DisplayName";
+                var xDisplayNameElem = properties.Element(xDisplayName);
 
-				// <Logo>
-				if (appIconInfo != null)
+                if (!string.IsNullOrEmpty(ApplicationTitle))
+				{
+					if (xDisplayNameElem == null || string.IsNullOrEmpty(xDisplayNameElem.Value) || xDisplayNameElem.Value == DefaultPlaceholder)
+					{
+						properties.SetElementValue(xDisplayName, ApplicationTitle);
+                    }
+                }
+
+				DisplayName = xDisplayNameElem.Value;
+
+                // <Logo>
+                if (appIconInfo != null)
 				{
 					var xname = xmlns + "Logo";
 					var xelem = properties.Element(xname);

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -51,7 +51,7 @@ namespace Uno.Resizetizer
 		public override bool Execute()
 		{
 #if DEBUG_RESIZETIZER
-	//		System.Diagnostics.Debugger.Launch();
+			System.Diagnostics.Debugger.Launch();
 #endif
 			try
 			{
@@ -146,22 +146,22 @@ namespace Uno.Resizetizer
 					appx.Root.Add(properties);
 				}
 
-                // <DisplayName>
-                var xDisplayName = xmlns + "DisplayName";
-                var xDisplayNameElem = properties.Element(xDisplayName);
+				// <DisplayName>
+				var xDisplayName = xmlns + "DisplayName";
+				var xDisplayNameElem = properties.Element(xDisplayName);
 
-                if (!string.IsNullOrEmpty(ApplicationTitle))
+				if (!string.IsNullOrEmpty(ApplicationTitle))
 				{
 					if (xDisplayNameElem == null || string.IsNullOrEmpty(xDisplayNameElem.Value) || xDisplayNameElem.Value == DefaultPlaceholder)
 					{
 						properties.SetElementValue(xDisplayName, ApplicationTitle);
-                    }
-                }
+					}
+				}
 
 				DisplayName = properties.Element(xDisplayName).Value;
 
-                // <Logo>
-                if (appIconInfo != null)
+				// <Logo>
+				if (appIconInfo != null)
 				{
 					var xname = xmlns + "Logo";
 					var xelem = properties.Element(xname);

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -158,7 +158,7 @@ namespace Uno.Resizetizer
                     }
                 }
 
-				DisplayName = xDisplayNameElem.Value;
+				DisplayName = properties.Element(xDisplayName).Value;
 
                 // <Logo>
                 if (appIconInfo != null)

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -147,18 +147,17 @@ namespace Uno.Resizetizer
 				}
 
 				// <DisplayName>
-				var xDisplayName = xmlns + "DisplayName";
-				var xDisplayNameElem = properties.Element(xDisplayName);
-
+				var xdisplayname = xmlns + "DisplayName";
 				if (!string.IsNullOrEmpty(ApplicationTitle))
 				{
-					if (xDisplayNameElem == null || string.IsNullOrEmpty(xDisplayNameElem.Value) || xDisplayNameElem.Value == DefaultPlaceholder)
+					var xelem = properties.Element(xdisplayname);
+					if (xelem == null || string.IsNullOrEmpty(xelem.Value) || xelem.Value == DefaultPlaceholder)
 					{
-						properties.SetElementValue(xDisplayName, ApplicationTitle);
+						properties.SetElementValue(xdisplayname, ApplicationTitle);
 					}
 				}
 
-				DisplayName = properties.Element(xDisplayName).Value;
+				DisplayName = properties.Element(xdisplayname).Value;
 
 				// <Logo>
 				if (appIconInfo != null)

--- a/src/Resizetizer/src/WindowIconGeneratorTask.cs
+++ b/src/Resizetizer/src/WindowIconGeneratorTask.cs
@@ -14,7 +14,6 @@ public class WindowIconGeneratorTask_V0 : Task
 	[Required]
 	public string IntermediateOutputDirectory { get; set; }
 
-	[Required]
 	public string WindowTitle { get; set; }
 
 	[Output]


### PR DESCRIPTION
Fixes: #208 
Replaces #209 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
On Windows targets, `AppWindow` currently lacks a default value for its `Title` property. 


In our task for generating window icon, we form the code to retrieve an `AppWindow` from the XAML `Window`, using it to conveniently set the generated `ico` file. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Upon retrieval of `AppWindow`, set AppWindow.Title to be the app's `DisplayName`. This value is obtained from the XAML `Window` instance which has a pre-defined `Title` property. (defaulting to `DisplayName`)

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): N/A
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
