### PR TITLE
Updates Sample to build against generated NuGet

### DIFF
--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,6 +1,24 @@
 <Project>
-  <PropertyGroup>
-    <_ResizetizerTargetsDirectory>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', 'src', '.nuspec'))</_ResizetizerTargetsDirectory>
-    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(_ResizetizerTargetsDirectory)\Uno.Resizetizer.targets</AfterMicrosoftNETSdkTargets>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Uno.Resizetizer" />
+  </ItemGroup>
+
+  <Target Name="GetResizetizerVersion"
+          BeforeTargets="CollectPackageReferences;Restore;_GetAllRestoreProjectPathItems">
+
+    <Error Text="You must runt `dotnet pack` on Uno.Resizetizer before building the samples."
+           Condition="!Exists('$(MSBuildThisFileDirectory)packages')" />
+
+    <ItemGroup>
+      <_LocalPackage Include="$(MSBuildThisFileDirectory)packages\Uno.Resizetizer.*.nupkg" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_LocalPackageVersion>$([System.Text.RegularExpressions.Regex]::Replace(%(_LocalPackage.Filename), '^(Uno\.Resizetizer\.)', ''))</_LocalPackageVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageVersion Include="Uno.Resizetizer" Version="$(_LocalPackageVersion)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/samples/nuget.config
+++ b/samples/nuget.config
@@ -1,0 +1,7 @@
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="LocalPackages" value="packages/" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -536,4 +536,36 @@
 		</ItemGroup>
 	</Target>
 
+	<!--
+		This is used to get and copy the native runtime assets. This is a workaround as the assets aren't properly loading
+	-->
+	<Target Name="_ResizetizerInitialize"
+		BeforeTargets="UnoResizetizeImages">
+		<PropertyGroup>
+			<_ResizetizerRuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</_ResizetizerRuntimeIdentifier>
+			<!-- NOTE: We may need to adjust this in the future if we end up with assets compiled for osx-arm64 and osx-x64 -->
+			<_ResizetizerRuntimeIdentifier Condition=" $(_ResizetizerRuntimeIdentifier.Contains('osx')) ">osx</_ResizetizerRuntimeIdentifier>
+			<_ResizetizerRuntimeIdentifierDirectory>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'netstandard2.0', 'runtimes', '$(_ResizetizerRuntimeIdentifier)'))</_ResizetizerRuntimeIdentifierDirectory>
+			<_ResizetizerRuntimeAssetsOutput>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'netstandard2.0'))</_ResizetizerRuntimeAssetsOutput>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<_ResiztizerRuntimeAssets Include="$(_ResizetizerRuntimeIdentifierDirectory)\**\*"
+				OutputDirectory="$(_ResizetizerRuntimeAssetsOutput)" />
+		</ItemGroup>
+
+		<Error Text="No Runtime was found."
+			Condition="$(_ResizetizerRuntimeIdentifier) == ''" />
+
+		<Error Text="The selected runtime directory does not exist"
+			Condition="!Exists('$(_ResizetizerRuntimeIdentifierDirectory)')" />
+
+		<Copy SourceFiles="@(_ResiztizerRuntimeAssets)"
+			DestinationFiles="@(_ResiztizerRuntimeAssets->'%(OutputDirectory)\%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true"
+			OverwriteReadOnlyFiles="true"
+			Condition="Exists('$(_ResizetizerRuntimeIdentifierDirectory)')" />
+
+	</Target>
+
 </Project>

--- a/src/Resizetizer/src/Resizetizer.csproj
+++ b/src/Resizetizer/src/Resizetizer.csproj
@@ -13,7 +13,11 @@
 		<!-- Version management is now done through NuGet, this avoids issues related version mismatch -->
 		<Version>255.255.255.255</Version>
 		<UnoNuspecDirectory>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '.nuspec'))</UnoNuspecDirectory>
+		<SamplesPackageDirectory>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '..', 'samples', 'packages'))</SamplesPackageDirectory>
 		<DefaultLanguage>en-US</DefaultLanguage>
+
+		<!-- Integration testing should happen with the NuGet and not local assets -->
+		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -22,10 +26,6 @@
 		<PackageId>Uno.Resizetizer</PackageId>
 		<Description>Uno Platform package support for images.</Description>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)'=='Release'">
-		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -74,38 +74,49 @@
 
 	<Import Project="../Directory.UnoMetadata.targets" />
 
+	<!-- Gets the Runtime Assets that need to be copied to the NuGet -->
 	<Target Name="GatherRuntimeAssets"
 		BeforeTargets="PackNuGetLockFiles;CopyAssetsForSampleProject">
 		<ItemGroup>
 			<_RuntimeAssets Include="@(RuntimeTargetsCopyLocalItems)"
+				DestinationSubDirectory="%(RuntimeTargetsCopyLocalItems.DestinationSubDirectory)"
+
 				OutputDirectory="$([System.Text.RegularExpressions.Regex]::Replace(%(RuntimeTargetsCopyLocalItems.RuntimeIdentifier), '^(linux|win)-', ''))"
 				Condition="%(RuntimeTargetsCopyLocalItems.RuntimeIdentifier) != 'win' AND %(RuntimeTargetsCopyLocalItems.RuntimeIdentifier) != 'unix'" />
 		</ItemGroup>
 	</Target>
 
+	<!-- Updates the NuGet assets with the output assemblies and Runtime assets -->
 	<Target Name="PackNuGetLockFiles"
 			BeforeTargets="DownloadAndSetPackageIcon;Pack;GenerateNuspec">
 		<ItemGroup>
 			<None Include="@(ReferenceCopyLocalPaths)" Pack="true" PackagePath="$(BuildOutputTargetFolder)/$(TargetFramework)" />
-			<None Include="@(_RuntimeAssets)" Pack="true" PackagePath="$(BuildOutputTargetFolder)/$(TargetFramework)/%(_RuntimeAssets.OutputDirectory)" />
+			<None Include="@(_RuntimeAssets)" Pack="true" PackagePath="$(BuildOutputTargetFolder)/$(TargetFramework)/%(_RuntimeAssets.DestinationSubDirectory)" />
 		</ItemGroup>
 	</Target>
 
-	<Target Name="CopyAssetsForSampleProject"
-		AfterTargets="Build">
+	<!-- Copies the generated NuGet for use with the sample apps -->
+	<Target Name="ResizetizerIntegrationTests"
+		AfterTargets="Pack">
+		<RemoveDir Directories="$(SamplesPackageDirectory)" />
+		<Copy SourceFiles="@(NuGetPackOutput)"
+			DestinationFolder="$(SamplesPackageDirectory)"
+			SkipUnchangedFiles="false"
+			OverwriteReadOnlyFiles="true"
+			Condition="%(Extension) == '.nupkg'" />
+	</Target>
+
+	<!-- Deletes the local cache files for the NuGet to assist in Dev/Testing -->
+	<Target Name="DeleteCachedPackage" Condition="'$(CI)' != 'true'" BeforeTargets="Pack">
 		<ItemGroup>
-			<_OutputFile Include="$(OutDir)\**\*.*" Exclude="$(OutDir)\**\*.targets"/>
+			<ToDelete Include="$(PackageOutputPath)\$(PackageId).$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)*.*" />
+			<ToDelete Include="$(LocalArtifactStagingDirectory)\$(PackageId).$(GitBaseVersionMajor).$(GitBaseVersionMinor).*" />
 		</ItemGroup>
-
-		<Copy SourceFiles="@(_OutputFile)"
-			DestinationFiles="@(_OutputFile->'$(UnoNuspecDirectory)$(TargetFramework)\%(Filename)%(Extension)')"
-			SkipUnchangedFiles="true"
-			OverwriteReadOnlyFiles="true" />
-
-		<Copy SourceFiles="@(_RuntimeAssets)"
-			DestinationFiles="@(_RuntimeAssets->'$(UnoNuspecDirectory)$(TargetFramework)\%(OutputDirectory)\%(Filename)%(Extension)')"
-			SkipUnchangedFiles="true"
-			OverwriteReadOnlyFiles="true" />
+		<Delete Files="@(ToDelete)" />
+		<Exec Command="rd &quot;$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())&quot; /q /s"
+			Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') And '$(OS)' == 'Windows_NT'" />
+		<Exec Command="rm -rf &quot;$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())&quot;"
+			Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') And '$(OS)' != 'Windows_NT'" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
Fixes: #

- fixes #225
- fixes canaries

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We rely on the runtime to resolve the correct runtime assets
We build the sample against locally built binaries

## What is the new behavior?

HACK: We have added a task to move the correct runtime assets to the executing directory for Resizetizer.
We build the sample against the generated NuGet package