### PR TITLE
fix: Aligns input/outputs of GenerateUnoSplashAndroid with GenerateUnoSplashScreens

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.android.targets
+++ b/src/.nuspec/Uno.Resizetizer.android.targets
@@ -3,9 +3,7 @@
 			Name="GenerateUnoSplashAndroid"
 			AfterTargets="GenerateUnoSplashScreens"
 			DependsOnTargets="GenerateUnoSplashScreens"
-			Inputs="$(_UnoSplashInputsFile);@(UnoSplashScreen)"
-			Outputs="$(_UnoSplashStampFile)"
-			Condition="'$(DesignTimeBuild)' != 'True' And '@(UnoSplashScreen)' != ''">
+			Condition=" '$(_ShouldRunPlatformGenerateUnoSplashScreens)' == 'true' and '$(DesignTimeBuild)' != 'True' And '@(UnoSplashScreen)' != ''">
 		<!-- Android -->
 		<GenerateSplashAndroidResources_v0
 				IntermediateOutputPath="$(_UnoIntermediateSplashScreen)"

--- a/src/.nuspec/Uno.Resizetizer.android.targets
+++ b/src/.nuspec/Uno.Resizetizer.android.targets
@@ -3,6 +3,8 @@
 			Name="GenerateUnoSplashAndroid"
 			AfterTargets="GenerateUnoSplashScreens"
 			DependsOnTargets="GenerateUnoSplashScreens"
+			Inputs="$(_UnoSplashInputsFile);@(UnoSplashScreen)"
+			Outputs="$(_UnoSplashStampFile)"
 			Condition="'$(DesignTimeBuild)' != 'True' And '@(UnoSplashScreen)' != ''">
 		<!-- Android -->
 		<GenerateSplashAndroidResources_v0

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -466,6 +466,15 @@
 			<FileWrites Include="$(_UnoSplashStampFile)"/>
 		</ItemGroup>
 
+		<!-- 
+			We cannot use Input/Output targets for GenerateUnoSplashAndroid (this target modifies them) so we 
+			propagate the requirement through a property.
+		-->
+		<CreateProperty Value="true">
+			<Output
+				PropertyName="_ShouldRunPlatformGenerateUnoSplashScreens" />
+		</CreateProperty>
+
 	</Target>
 
 	<Target Name="UnoResizetizeImages"

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -472,7 +472,14 @@
 		-->
 		<CreateProperty Value="true">
 			<Output
+				TaskParameter="Value"
 				PropertyName="_ShouldRunPlatformGenerateUnoSplashScreens" />
+		</CreateProperty>
+
+		<CreateProperty Value="x86">
+			<Output
+				TaskParameter="Value"
+				PropertyName="_WindowsAppSDKFoundationPlatform" />
 		</CreateProperty>
 
 	</Target>


### PR DESCRIPTION
This avoids  GenerateUnoSplashAndroid to run even if GenerateUnoSplashScreens was ignore for input/output rules, later causing Aapt2Compile to run on removed files.

Fixes https://github.com/unoplatform/uno.resizetizer/issues/232