### PR TITLE
Add error when Processor Architecture doesn't match Runtime

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -639,6 +639,9 @@
 				OutputDirectory="$(_ResizetizerRuntimeAssetsOutput)" />
 		</ItemGroup>
 
+		<Error Text="The Processor Architecture '$(PROCESSOR_ARCHITECTURE)' does not match the current tooling Runtime '$(NETCoreSdkRuntimeIdentifier)'. Be sure to build within the correct runtime environment as the .NET Tooling."
+			Condition="'$(NETCoreSdkRuntimeIdentifier)' != '' AND $(NETCoreSdkRuntimeIdentifier.Contains('win-')) AND '$(PROCESSOR_ARCHITECTURE)' != '' AND !$(NETCoreSdkRuntimeIdentifier.Contains('$(PROCESSOR_ARCHITECTURE.Replace('AMD', 'x'))'))" />
+
 		<Error Text="No Runtime was found."
 			Condition="$(_ResizetizerRuntimeIdentifier) == ''" />
 


### PR DESCRIPTION
Fixes: #

- resolves #263

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If the Processor Architecture does not match the Runtime Architecture of the dotnet tooling an invalid runtime will be selected by for the compiled runtime assets for SkiaSharp

## What is the new behavior?

If there is a mismatch on Windows where the Processor is x86 and the runtime is x64 we will now raise a build error letting you know that the environment is not valid. This includes a check for `AMD64` so that we normalize this value allowing the check to pass for `x64` since the two are compatible.