### PR TITLE
Update Window Title logic

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -595,7 +595,7 @@
 			Outputs="@(_WindowIconExtension)">
 
 		<PropertyGroup>
-			<WindowTitle Condition="'$(WindowTitle)' == ''">$(ApplicationTitle)</WindowTitle>
+			<WindowTitle Condition="'$(WindowTitle)' == ''">$([MSBuild]::ValueOrDefault('$(ApplicationTitle)', '$(AssemblyName)'))</WindowTitle>
 		</PropertyGroup>
 
 		<WindowIconGeneratorTask_v0

--- a/src/Resizetizer/src/WindowIconGeneratorTask.cs
+++ b/src/Resizetizer/src/WindowIconGeneratorTask.cs
@@ -69,7 +69,27 @@ namespace Uno.Resizetizer
 			global::Microsoft.UI.Windowing.AppWindow appWindow =
 				global::Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
 			appWindow.SetIcon(""{iconName}.ico"");
-			appWindow.Title = ""{WindowTitle}"";
+
+			// Set the Window Title Only if it has the Default WinUI Desktop value and we are running Unpackaged
+			if (!IsPackaged() && appWindow.Title == ""WinUI Desktop"")
+			{{
+				appWindow.Title = ""{WindowTitle}"";
+			}}
+
+			static bool IsPackaged()
+			{{
+				try
+				{{
+					if (Package.Current != null)
+						return true;
+				}}
+				catch
+				{{
+					// no-op
+				}}
+
+				return false;
+			}}
 #endif
 		}}
 	}}

--- a/src/Resizetizer/src/WindowIconGeneratorTask.cs
+++ b/src/Resizetizer/src/WindowIconGeneratorTask.cs
@@ -80,7 +80,7 @@ namespace Uno.Resizetizer
 			{{
 				try
 				{{
-					if (Package.Current != null)
+					if (global::Windows.ApplicationModel.Package.Current != null)
 						return true;
 				}}
 				catch


### PR DESCRIPTION
Fixes: #

- closes #267

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The Window title is always set on Windows


## What is the new behavior?

The Window title is ONLY set on Windows when Unpackaged and if the Window title has the default `WinUI Desktop` value.