### PR TITLE
Fix appxmanifest merge

### DIFF
--- a/samples/5.2/Uno52ResizetizerTests/Uno52ResizetizerTests/Package.appxmanifest
+++ b/samples/5.2/Uno52ResizetizerTests/Uno52ResizetizerTests/Package.appxmanifest
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
@@ -7,13 +6,13 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="Uno52ResizetizerTests"
+    Name="$placeholder$"
     Publisher="O=Uno52ResizetizerTests"
-    Version="1.0.0.0" />
+    Version="0.0.0.0" />
 
   <Properties>
-    <DisplayName>Uno52ResizetizerTests</DisplayName>
-    <PublisherDisplayName>Uno52ResizetizerTests</PublisherDisplayName>
+    <DisplayName>$placeholder$</DisplayName>
+    <PublisherDisplayName>$placeholder$</PublisherDisplayName>
   </Properties>
 
   <Dependencies>

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -68,26 +68,16 @@
 			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
 			Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
 
-
-		<PropertyGroup>
-			<_UnoWindowsApplicationId
-					Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationIdGuid)' != ''">
-				$(ApplicationIdGuid)
-			</_UnoWindowsApplicationId>
-			<_UnoWindowsApplicationId
-					Condition="'$(_UnoWindowsApplicationId)' == '' and '$(ApplicationId)' != ''">
-				$(ApplicationId)
-			</_UnoWindowsApplicationId>
-		</PropertyGroup>
-
 		<GeneratePackageAppxManifest_v0
 				IntermediateOutputPath="$(_UnoIntermediateManifest)"
 				AppxManifest="@(AppxManifest);@(_UnoAppxManifest);@(_SkiaManifest)"
 				GeneratedFilename="Package.appxmanifest"
-				ApplicationId="$(_UnoWindowsApplicationId)"
+				ApplicationId="$(ApplicationId)"
 				ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 				ApplicationVersion="$(ApplicationVersion)"
 				ApplicationTitle="$(ApplicationTitle)"
+				AssemblyName="$(AssemblyName)"
+				Description="$(Description)"
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
 				TargetFramework="$(_UnoResizetizerPlatformIdentifier)"
 				SplashScreen="@(UnoSplashScreen)">

--- a/src/Resizetizer/test/UnitTests/GeneratePackageAppxManifestTests.cs
+++ b/src/Resizetizer/test/UnitTests/GeneratePackageAppxManifestTests.cs
@@ -15,10 +15,11 @@ namespace Uno.Resizetizer.Tests
 		protected GeneratePackageAppxManifest_v0 GetNewTask(
 			string manifest,
 			string? generatedFilename = null,
-			string? guid = null,
+			string? applicationId = null,
 			string? displayVersion = null,
 			string? version = null,
 			string? displayName = null,
+			string? description = null,
 			ITaskItem? appIcon = null,
 			ITaskItem? splashScreen = null)
 		{
@@ -28,10 +29,13 @@ namespace Uno.Resizetizer.Tests
 				BuildEngine = this,
 				GeneratedFilename = generatedFilename,
 				AppxManifest = new []{new TaskItem(manifest)},
-				ApplicationId = guid,
+				ApplicationId = applicationId,
 				ApplicationDisplayVersion = displayVersion,
 				ApplicationVersion = version,
-				ApplicationTitle = displayName,AppIcon = appIcon == null ? null : new[] { appIcon },
+				ApplicationTitle = displayName,
+				AssemblyName = GetType().Assembly.FullName,
+				Description = description,
+				AppIcon = appIcon == null ? null : new[] { appIcon },
 				SplashScreen = splashScreen == null ? null : new[] { splashScreen },
 				TargetFramework = "windows"
 			};
@@ -40,10 +44,11 @@ namespace Uno.Resizetizer.Tests
 		protected GeneratePackageAppxManifest_v0 GetNewTask(
 		ITaskItem[] appxManifests,
 		string? generatedFilename = null,
-		string? guid = null,
+		string? applicationId = null,
 		string? displayVersion = null,
 		string? version = null,
 		string? displayName = null,
+		string? description = null,
 		ITaskItem? appIcon = null,
 		ITaskItem? splashScreen = null)
 		{
@@ -53,10 +58,13 @@ namespace Uno.Resizetizer.Tests
 				BuildEngine = this,
 				GeneratedFilename = generatedFilename,
 				AppxManifest = appxManifests,
-				ApplicationId = guid,
+				ApplicationId = applicationId,
 				ApplicationDisplayVersion = displayVersion,
 				ApplicationVersion = version,
-				ApplicationTitle = displayName,AppIcon = appIcon == null ? null : new[] { appIcon },
+				ApplicationTitle = displayName,
+				Description = description,
+                AssemblyName = GetType().Assembly.FullName,
+                AppIcon = appIcon == null ? null : new[] { appIcon },
 				SplashScreen = splashScreen == null ? null : new[] { splashScreen },
 				TargetFramework = "windows"
 			};
@@ -88,7 +96,7 @@ namespace Uno.Resizetizer.Tests
 
 			var inputFilename = $"testdata/appxmanifest/typical.appxmanifest";
 			var task = GetNewTask(inputFilename,
-				guid: "3505f9e4-fa3e-4742-d1ac-daff4ec89b2b",
+                applicationId: "com.contoso.myapp",
 				displayVersion: "2.5",
 				version: "3",
 				displayName: "Fishy Things",
@@ -126,14 +134,12 @@ namespace Uno.Resizetizer.Tests
 
 			var inputFilename = $"testdata/appxmanifest/{input}.appxmanifest";
 			var task = GetNewTask(inputFilename,
-				guid: "f9e4fa3e-3505-4742-9b2b-d1acdaff4ec8",
+                applicationId: "com.contoso.myapp",
 				displayVersion: "1.0.0",
 				version: "1",
 				displayName: "Sample App",
 				appIcon: appIcon,
 				splashScreen: splashScreen);
-
-
 
 			var success = task.Execute();
 			Assert.True(success, $"{task.GetType()}.Execute() failed: " + LogErrorEvents.FirstOrDefault()?.Message);
@@ -164,7 +170,7 @@ namespace Uno.Resizetizer.Tests
 
 			var inputFilename = $"testdata/appxmanifest/{input}.appxmanifest";
 			var task = GetNewTask(inputFilename,
-				guid: "f9e4fa3e-3505-4742-9b2b-d1acdaff4ec8",
+				applicationId: "com.contoso.myapp",
 				displayVersion: "1.0.0",
 				version: "1",
 				displayName: "Sample App",

--- a/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typical.appxmanifest
+++ b/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typical.appxmanifest
@@ -3,7 +3,7 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap rescap">
-    <Identity Publisher="CN=.NET Foundation" Name="f9e4fa3e-3505-4742-9b2b-d1acdaff4ec8" Version="1.0.0.1" />
+    <Identity Publisher="CN=.NET Foundation" Name="com.contoso.myapp" Version="1.0.0.1" />
     <Properties>
         <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
         <DisplayName>Sample App</DisplayName>

--- a/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typicalWithNoBackground.appxmanifest
+++ b/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typicalWithNoBackground.appxmanifest
@@ -3,7 +3,7 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap rescap">
-    <Identity Publisher="CN=.NET Foundation" Name="f9e4fa3e-3505-4742-9b2b-d1acdaff4ec8" Version="1.0.0.1" />
+    <Identity Publisher="CN=.NET Foundation" Name="com.contoso.myapp" Version="1.0.0.1" />
     <Properties>
         <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
         <DisplayName>Sample App</DisplayName>
@@ -19,7 +19,7 @@
     <Applications>
         <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
             <uap:VisualElements DisplayName="Sample App" Description="Sample App" BackgroundColor="#ffffff" Square150x150Logo="images\appiconMediumTile.png" Square44x44Logo="images\appiconLogo.png">
-                <uap:DefaultTile Wide310x150Logo="images\appiconWideTile.png" Square71x71Logo="images\appiconSmallTile.png" Square310x310Logo="images\appiconLargeTile.png" ShortName="Sample App">
+                <uap:DefaultTile ShortName="Sample App" Wide310x150Logo="images\appiconWideTile.png" Square71x71Logo="images\appiconSmallTile.png" Square310x310Logo="images\appiconLargeTile.png">
                     <uap:ShowNameOnTiles>
                         <uap:ShowOn Tile="square150x150Logo" />
                         <uap:ShowOn Tile="wide310x150Logo" />


### PR DESCRIPTION
Fixes: #

- fixes #272

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Properties like the Application Title and Version numbers are not correctly applied. 

## What is the new behavior?

Refactors the execution logic to simplify away from heavily nested if statements.

This now correctly applies the Application Title, and other common Single Project MSBuild properties.