### PR TITLE
Update Publisher

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -64,9 +64,7 @@
 	<Target Name="UnoGeneratePackageAppxManifest"
 			Condition="('$(_UnoResizetizerIsWindowsAppSdk)' == 'True' Or '$(_UnoResizetizerIsSkiaApp)' == 'True') And ('@(AppxManifest)@(_UnoAppxManifest)' !='' Or @(_SkiaManifest) != '')"
 			DependsOnTargets="$(UnoGeneratePackageAppxManifestDependsOnTargets)"
-			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets);_GenerateWindowUnoIconExtension"
-			Inputs="$(MSBuildThisFileFullPath);$(_UnoResizetizerTaskAssemblyName);$(_UnoResizetizerInputsFile);$(_UnoSplashInputsFile);@(AppxManifest);@(_UnoAppxManifest)"
-			Outputs="$(_UnoManifestStampFile);$(_UnoIntermediateManifest)Package.appxmanifest">
+			BeforeTargets="$(UnoGeneratePackageAppxManifestBeforeTargets);_GenerateWindowUnoIconExtension">
 
 		<GeneratePackageAppxManifest_v0
 				IntermediateOutputPath="$(_UnoIntermediateManifest)"

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -80,6 +80,8 @@
 				Authors="$(Authors)"
 				AssemblyName="$(AssemblyName)"
 				Description="$(Description)"
+				TargetPlatformMinVersion="$(TargetPlatformMinVersion)"
+				TargetPlatformVersion="$(TargetPlatformVersion)"
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"
 				TargetFramework="$(_UnoResizetizerPlatformIdentifier)"
 				SplashScreen="@(UnoSplashScreen)">

--- a/src/.nuspec/Uno.Resizetizer.windows.skia.targets
+++ b/src/.nuspec/Uno.Resizetizer.windows.skia.targets
@@ -76,6 +76,8 @@
 				ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 				ApplicationVersion="$(ApplicationVersion)"
 				ApplicationTitle="$(ApplicationTitle)"
+				ApplicationPublisher="$(ApplicationPublisher)"
+				Authors="$(Authors)"
 				AssemblyName="$(AssemblyName)"
 				Description="$(Description)"
 				AppIcon="@(UnoImage->WithMetadataValue('IsAppIcon', 'true'))"

--- a/src/Resizetizer/src/GeneratePackageAppxManifest.cs
+++ b/src/Resizetizer/src/GeneratePackageAppxManifest.cs
@@ -41,6 +41,8 @@ namespace Uno.Resizetizer
 
 		public string? Authors { get; set; }
 
+		public string? ApplicationPublisher { get; set; }
+
 		public string? Description { get; set; }
 
 		public ITaskItem[]? AppIcon { get; set; }
@@ -64,6 +66,7 @@ namespace Uno.Resizetizer
 				ApplicationId ??= AssemblyName;
 				Description ??= ApplicationTitle;
 				Authors ??= ApplicationTitle;
+				ApplicationPublisher ??= Authors;
 
 				ResizetizeImages_v0._TargetFramework = TargetFramework;
 				Directory.CreateDirectory(IntermediateOutputPath);
@@ -110,6 +113,9 @@ namespace Uno.Resizetizer
 
 			// Name=""
 			UpdateIdentityName(identity);
+
+			// Publisher=""
+			UpdateIdentityPublisher(identity);
 
 			// Version=""
 			UpdateIdentityVersion(identity);
@@ -247,6 +253,19 @@ namespace Uno.Resizetizer
 			}
 		}
 
+		private void UpdateIdentityPublisher(XElement identity)
+		{
+			if (!string.IsNullOrEmpty(ApplicationPublisher))
+			{
+				var xpublisher = "Publisher";
+				var attr = identity.Attribute(xpublisher);
+				if (attr == null || string.IsNullOrEmpty(attr.Value) || attr.Value == DefaultPlaceholder)
+				{
+					identity.SetAttributeValue(xpublisher, $"O={ApplicationPublisher}");
+				}
+			}
+		}
+
 		private void UpdateIdentityVersion(XElement identity)
 		{
 			ApplicationDisplayVersion ??= "1.0.0";
@@ -285,12 +304,12 @@ namespace Uno.Resizetizer
 		{
 			// <PublisherDisplayName>
 			var xpublisherDisplayName = xmlns + "PublisherDisplayName";
-			if (!string.IsNullOrEmpty(Authors))
+			if (!string.IsNullOrEmpty(ApplicationPublisher))
 			{
 				var xelem = properties.Element(xpublisherDisplayName);
 				if (xelem == null || string.IsNullOrEmpty(xelem.Value) || xelem.Value == DefaultPlaceholder)
 				{
-					properties.SetElementValue(xpublisherDisplayName, Authors);
+					properties.SetElementValue(xpublisherDisplayName, ApplicationPublisher);
 				}
 			}
 		}

--- a/src/Resizetizer/test/UnitTests/testdata/appxmanifest/empty.appxmanifest
+++ b/src/Resizetizer/test/UnitTests/testdata/appxmanifest/empty.appxmanifest
@@ -3,9 +3,9 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap rescap">
-    <Identity Publisher="CN=.NET Foundation" />
+    <Identity Publisher="CN=Uno Platform" />
     <Properties>
-        <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
+        <PublisherDisplayName>Uno Platform</PublisherDisplayName>
     </Properties>
     <Dependencies>
         <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />

--- a/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typical.appxmanifest
+++ b/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typical.appxmanifest
@@ -3,9 +3,9 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap rescap">
-    <Identity Publisher="CN=.NET Foundation" Name="com.contoso.myapp" Version="1.0.0.1" />
+    <Identity Publisher="CN=Uno Platform" Name="com.contoso.myapp" Version="1.0.0.1" />
     <Properties>
-        <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
+        <PublisherDisplayName>Uno Platform</PublisherDisplayName>
         <DisplayName>Sample App</DisplayName>
         <Logo>images\appiconStoreLogo.png</Logo>
     </Properties>

--- a/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typicalWithNoBackground.appxmanifest
+++ b/src/Resizetizer/test/UnitTests/testdata/appxmanifest/typicalWithNoBackground.appxmanifest
@@ -3,9 +3,9 @@
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap rescap">
-    <Identity Publisher="CN=.NET Foundation" Name="com.contoso.myapp" Version="1.0.0.1" />
+    <Identity Publisher="CN=Uno Platform" Name="com.contoso.myapp" Version="1.0.0.1" />
     <Properties>
-        <PublisherDisplayName>.NET Foundation</PublisherDisplayName>
+        <PublisherDisplayName>Uno Platform</PublisherDisplayName>
         <DisplayName>Sample App</DisplayName>
         <Logo>images\appiconStoreLogo.png</Logo>
     </Properties>


### PR DESCRIPTION
Fixes: #

- fixes #280 
- related unoplatform/uno#16618

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

TargetDeviceFamilies are not updated with the TargetPlatformVersion and the TargetPlatformMinVersion provided by MSBuild. We do not have a property that handles the Identity Publisher

## What is the new behavior?

We now will set the Publisher Display Name and the Identity Publisher values in the AppxManifest via the new ApplicationPublisher MSBuild property if it exists. If it does not exist it will fall back to the Authors property which falls back to the Application Title and ultimately the Assembly Name. This ensures there is always a value for these even if the properties were not directly supplied.

This will now check for any TargetDeviceFamily elements within the Dependencies. If none exists it will add one for `Windows.Universal` and `Windows.Desktop` which are the defaults in the WinUI and the Uno Templates. If the `MinVersion` or `MaxVersionTested` attributes are either not set or have a default value of `0.0.0.0` it will use the `TargetPlatformVersion` and `TargetPlatormMinVersion` to set these attributes.