### PR TITLE
Generate AppIconSet for Desktop on MacOS

### DIFF
--- a/src/Resizetizer/src/AppleIconAssetsGenerator.cs
+++ b/src/Resizetizer/src/AppleIconAssetsGenerator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -33,8 +34,9 @@ namespace Uno.Resizetizer
 		{
 			var outputAppIconSetDir = Path.Combine(IntermediateOutputPath, DpiPath.Ios.AppIconPath.Replace("{name}", AppIconName));
 			var outputAssetsDir = Path.Combine(outputAppIconSetDir, "..");
+			var targetIdiom = Dpis.Any(x => x.Idioms.Contains("mac")) ? "MacOS" : "iOS";
 
-			Logger.Log("iOS App Icon Set Directory: " + outputAppIconSetDir);
+			Logger.Log($"{targetIdiom} App Icon Set Directory: " + outputAppIconSetDir);
 
 			Directory.CreateDirectory(outputAppIconSetDir);
 

--- a/src/Resizetizer/src/DpiPath.cs
+++ b/src/Resizetizer/src/DpiPath.cs
@@ -1,4 +1,4 @@
-﻿using SkiaSharp;
+using SkiaSharp;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -63,20 +63,20 @@ namespace Uno.Resizetizer
 
 			public static DpiPath[] AppIcon =>
 				[
-					new DpiPath(AppIconPath, 1.0m, "16x16", "1x", new SKSize(16, 16), ["mac"]),
-					new DpiPath(AppIconPath, 2.0m, "16x16", "2x", new SKSize(16, 16), ["mac"]),
+					new DpiPath(AppIconPath, 1.0m, "16x16", "@1x", new SKSize(16, 16), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "16x16", "@2x", new SKSize(16, 16), ["mac"]),
 
-					new DpiPath(AppIconPath, 1.0m, "32x32", "1x", new SKSize(32, 32), ["mac"]),
-					new DpiPath(AppIconPath, 2.0m, "32x32", "2x", new SKSize(32, 32), ["mac"]),
+					new DpiPath(AppIconPath, 1.0m, "32x32", "@1x", new SKSize(32, 32), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "32x32", "@2x", new SKSize(32, 32), ["mac"]),
 
-					new DpiPath(AppIconPath, 1.0m, "128x128", "1x", new SKSize(128, 128), ["mac"]),
-					new DpiPath(AppIconPath, 2.0m, "128x128", "2x", new SKSize(128, 128), ["mac"]),
+					new DpiPath(AppIconPath, 1.0m, "128x128", "@1x", new SKSize(128, 128), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "128x128", "@2x", new SKSize(128, 128), ["mac"]),
 
-					new DpiPath(AppIconPath, 1.0m, "256x256", "1x", new SKSize(256, 256), ["mac"]),
-					new DpiPath(AppIconPath, 2.0m, "256x256", "2x", new SKSize(256, 256), ["mac"]),
+					new DpiPath(AppIconPath, 1.0m, "256x256", "@1x", new SKSize(256, 256), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "256x256", "@2x", new SKSize(256, 256), ["mac"]),
 
-					new DpiPath(AppIconPath, 1.0m, "512x512", "1x", new SKSize(512, 512), ["mac"]),
-					new DpiPath(AppIconPath, 2.0m, "512x512", "2x", new SKSize(512, 512), ["mac"]),
+					new DpiPath(AppIconPath, 1.0m, "512x512", "@1x", new SKSize(512, 512), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "512x512", "@2x", new SKSize(512, 512), ["mac"]),
 				];
 		}
 

--- a/src/Resizetizer/src/DpiPath.cs
+++ b/src/Resizetizer/src/DpiPath.cs
@@ -1,6 +1,8 @@
 ﻿using SkiaSharp;
+using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Uno.Resizetizer
 {
@@ -36,25 +38,46 @@ namespace Uno.Resizetizer
 
 		public static class Android
 		{
-			public static DpiPath[] AppIcon
-				=> new[]
-				{
+			public static DpiPath[] AppIcon =>
+				[
 					new DpiPath("mipmap-mdpi", 1.0m, size: new SKSize(48, 48)),
 					new DpiPath("mipmap-hdpi", 1.5m, size: new SKSize(48, 48)),
 					new DpiPath("mipmap-xhdpi", 2.0m, size: new SKSize(48, 48)),
 					new DpiPath("mipmap-xxhdpi", 3.0m, size: new SKSize(48, 48)),
 					new DpiPath("mipmap-xxxhdpi", 4.0m, size: new SKSize(48, 48)),
-				};
+				];
 
-			public static DpiPath[] AppIconParts
-				=> new[]
-				{
+			public static DpiPath[] AppIconParts =>
+				[
 					new DpiPath("mipmap-mdpi", 1.0m, size: new SKSize(108, 108)),
 					new DpiPath("mipmap-hdpi", 1.5m, size: new SKSize(108, 108)),
 					new DpiPath("mipmap-xhdpi", 2.0m, size: new SKSize(108, 108)),
 					new DpiPath("mipmap-xxhdpi", 3.0m, size: new SKSize(108, 108)),
 					new DpiPath("mipmap-xxxhdpi", 4.0m, size: new SKSize(108, 108)),
-				};
+				];
+		}
+
+		public static class MacOS
+		{
+			public const string AppIconPath = "Assets.xcassets/{name}.appiconset";
+
+			public static DpiPath[] AppIcon =>
+				[
+					new DpiPath(AppIconPath, 1.0m, "16x16", "1x", new SKSize(16, 16), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "16x16", "2x", new SKSize(16, 16), ["mac"]),
+
+					new DpiPath(AppIconPath, 1.0m, "32x32", "1x", new SKSize(32, 32), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "32x32", "2x", new SKSize(32, 32), ["mac"]),
+
+					new DpiPath(AppIconPath, 1.0m, "128x128", "1x", new SKSize(128, 128), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "128x128", "2x", new SKSize(128, 128), ["mac"]),
+
+					new DpiPath(AppIconPath, 1.0m, "256x256", "1x", new SKSize(256, 256), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "256x256", "2x", new SKSize(256, 256), ["mac"]),
+
+					new DpiPath(AppIconPath, 1.0m, "512x512", "1x", new SKSize(512, 512), ["mac"]),
+					new DpiPath(AppIconPath, 2.0m, "512x512", "2x", new SKSize(512, 512), ["mac"]),
+				];
 		}
 
 		public static class Ios
@@ -62,34 +85,33 @@ namespace Uno.Resizetizer
 			public const string AppIconPath = "Assets.xcassets/{name}.appiconset";
 
 			public static DpiPath Original =>
-				new DpiPath("Resources", 1.0m);
+				new ("Resources", 1.0m);
 
-			public static DpiPath[] AppIcon
-				=> new[]
-				{
+			public static DpiPath[] AppIcon =>
+				[
 					// Notification
-					new DpiPath(AppIconPath, 2.0m, "20x20", "@2x", new SKSize(20, 20), new [] { "iphone", "ipad" }),
-					new DpiPath(AppIconPath, 3.0m, "20x20", "@3x", new SKSize(20, 20), new [] { "iphone" }),
+					new DpiPath(AppIconPath, 2.0m, "20x20", "@2x", new SKSize(20, 20), ["iphone", "ipad"]),
+					new DpiPath(AppIconPath, 3.0m, "20x20", "@3x", new SKSize(20, 20), ["iphone"]),
 
 					// Settings
-					new DpiPath(AppIconPath, 2.0m, "29x29", "@2x", new SKSize(29, 29), new [] { "iphone", "ipad" }),
-					new DpiPath(AppIconPath, 3.0m, "29x29", "@3x", new SKSize(29, 29), new [] { "iphone" }),
+					new DpiPath(AppIconPath, 2.0m, "29x29", "@2x", new SKSize(29, 29), ["iphone", "ipad"]),
+					new DpiPath(AppIconPath, 3.0m, "29x29", "@3x", new SKSize(29, 29), ["iphone"]),
 
 					// Spotlight
-					new DpiPath(AppIconPath, 2.0m, "40x40", "@2x", new SKSize(40, 40), new [] { "iphone", "ipad" }),
-					new DpiPath(AppIconPath, 3.0m, "40x40", "@3x", new SKSize(40, 40), new [] { "iphone" }),
+					new DpiPath(AppIconPath, 2.0m, "40x40", "@2x", new SKSize(40, 40), ["iphone", "ipad"]),
+					new DpiPath(AppIconPath, 3.0m, "40x40", "@3x", new SKSize(40, 40), ["iphone"]),
 
 					// App Icon - iPhone
-					new DpiPath(AppIconPath, 2.0m, "60x60", "@2x", new SKSize(60, 60), new [] { "iphone" }),
-					new DpiPath(AppIconPath, 3.0m, "60x60", "@3x", new SKSize(60, 60), new [] { "iphone" }),
+					new DpiPath(AppIconPath, 2.0m, "60x60", "@2x", new SKSize(60, 60), ["iphone"]),
+					new DpiPath(AppIconPath, 3.0m, "60x60", "@3x", new SKSize(60, 60), ["iphone"]),
 
 					// App Icon - ipad
-					new DpiPath(AppIconPath, 2.0m, "76x76", "@2x", new SKSize(76, 76), new [] { "ipad" }),
-					new DpiPath(AppIconPath, 2.0m, "83.5x83.5", "@2x", new SKSize(83.5f, 83.5f), new [] { "ipad" }),
+					new DpiPath(AppIconPath, 2.0m, "76x76", "@2x", new SKSize(76, 76), ["ipad"]),
+					new DpiPath(AppIconPath, 2.0m, "83.5x83.5", "@2x", new SKSize(83.5f, 83.5f), ["ipad"]),
 
 					// App Store
-					new DpiPath(AppIconPath, 1.0m, "ItunesArtwork", null, new SKSize(1024, 1024), new [] { "ios-marketing" }),
-				};
+					new DpiPath(AppIconPath, 1.0m, "ItunesArtwork", null, new SKSize(1024, 1024), ["ios-marketing"]),
+				];
 		}
 
 		public static class Windows
@@ -98,11 +120,10 @@ namespace Uno.Resizetizer
 			public const string IconOutputPath = "";
 
 			public static DpiPath Original =>
-				new DpiPath(OutputPath, 1.0m, null, ".scale-100");
+				new (OutputPath, 1.0m, null, ".scale-100");
 
-			public static DpiPath[] Image
-				=> new[]
-				{
+			public static DpiPath[] Image =>
+				[
 					new DpiPath(OutputPath, 1.00m, null, ""), // Include a 1x version without the scale suffix
 					new DpiPath(OutputPath, 1.00m, null, ".scale-100"),
 					new DpiPath(OutputPath, 1.25m, null, ".scale-125"),
@@ -110,23 +131,21 @@ namespace Uno.Resizetizer
 					new DpiPath(OutputPath, 2.00m, null, ".scale-200"),
 					new DpiPath(OutputPath, 3.00m, null, ".scale-300"),
 					new DpiPath(OutputPath, 4.00m, null, ".scale-400"),
-				};
+				];
 
-			public static DpiPath[] SplashScreen
-				=> new[]
-				{
+			public static DpiPath[] SplashScreen =>
+				[
 					new DpiPath(OutputPath, 1.00m, string.Empty, ".scale-100", new SKSize(620, 300)),
 					new DpiPath(OutputPath, 1.25m, string.Empty, ".scale-125", new SKSize(620, 300)),
 					new DpiPath(OutputPath, 1.50m, string.Empty, ".scale-150", new SKSize(620, 300)),
 					new DpiPath(OutputPath, 2.00m, string.Empty, ".scale-200", new SKSize(620, 300)),
 					new DpiPath(OutputPath, 3.00m, string.Empty, ".scale-300", new SKSize(620, 300)),
 					new DpiPath(OutputPath, 4.00m, string.Empty, ".scale-400", new SKSize(620, 300)),
-				};
+				];
 
 			// App Icon
-			public static DpiPath[] Logo
-				=> new[]
-				{
+			public static DpiPath[] Logo =>
+				[
 					// normal
 					new DpiPath(IconOutputPath, 1.00m, "Logo", ".scale-100", new SKSize(44, 44)),
 					new DpiPath(IconOutputPath, 1.25m, "Logo", ".scale-125", new SKSize(44, 44)),
@@ -151,73 +170,67 @@ namespace Uno.Resizetizer
 					new DpiPath(IconOutputPath, 1.00m, "Logo", ".altform-lightunplated_targetsize-32", new SKSize(32, 32)),
 					new DpiPath(IconOutputPath, 1.00m, "Logo", ".altform-lightunplated_targetsize-48", new SKSize(48, 48)),
 					new DpiPath(IconOutputPath, 1.00m, "Logo", ".altform-lightunplated_targetsize-256", new SKSize(256, 256)),
-				};
+				];
 
 			// Store Logo
-			public static DpiPath[] StoreLogo
-				=> new[]
-				{
+			public static DpiPath[] StoreLogo =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "StoreLogo", ".scale-100", new SKSize(50, 50)),
 					new DpiPath(IconOutputPath, 1.25m, "StoreLogo", ".scale-125", new SKSize(50, 50)),
 					new DpiPath(IconOutputPath, 1.50m, "StoreLogo", ".scale-150", new SKSize(50, 50)),
 					new DpiPath(IconOutputPath, 2.00m, "StoreLogo", ".scale-200", new SKSize(50, 50)),
 					new DpiPath(IconOutputPath, 4.00m, "StoreLogo", ".scale-400", new SKSize(50, 50)),
-				};
+				];
 
 			// Small Tile
-			public static DpiPath[] SmallTile
-				=> new[]
-				{
+			public static DpiPath[] SmallTile =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "SmallTile", ".scale-100", new SKSize(71, 71)),
 					new DpiPath(IconOutputPath, 1.25m, "SmallTile", ".scale-125", new SKSize(71, 71)),
 					new DpiPath(IconOutputPath, 1.50m, "SmallTile", ".scale-150", new SKSize(71, 71)),
 					new DpiPath(IconOutputPath, 2.00m, "SmallTile", ".scale-200", new SKSize(71, 71)),
 					new DpiPath(IconOutputPath, 4.00m, "SmallTile", ".scale-400", new SKSize(71, 71)),
-				};
+				];
 
 			// Medium Tile
-			public static DpiPath[] MediumTile
-				=> new[]
-				{
+			public static DpiPath[] MediumTile =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "MediumTile", ".scale-100", new SKSize(150, 150)),
 					new DpiPath(IconOutputPath, 1.25m, "MediumTile", ".scale-125", new SKSize(150, 150)),
 					new DpiPath(IconOutputPath, 1.50m, "MediumTile", ".scale-150", new SKSize(150, 150)),
 					new DpiPath(IconOutputPath, 2.00m, "MediumTile", ".scale-200", new SKSize(150, 150)),
 					new DpiPath(IconOutputPath, 4.00m, "MediumTile", ".scale-400", new SKSize(150, 150)),
-				};
+				];
 
 			// Wide Tile
-			public static DpiPath[] WideTile
-				=> new[]
-				{
+			public static DpiPath[] WideTile =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "WideTile", ".scale-100", new SKSize(310, 150)),
 					new DpiPath(IconOutputPath, 1.25m, "WideTile", ".scale-125", new SKSize(310, 150)),
 					new DpiPath(IconOutputPath, 1.50m, "WideTile", ".scale-150", new SKSize(310, 150)),
 					new DpiPath(IconOutputPath, 2.00m, "WideTile", ".scale-200", new SKSize(310, 150)),
 					new DpiPath(IconOutputPath, 4.00m, "WideTile", ".scale-400", new SKSize(310, 150)),
-				};
+				];
 
 			// Large Tile
-			public static DpiPath[] LargeTile
-				=> new[]
-				{
+			public static DpiPath[] LargeTile =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "LargeTile", ".scale-100", new SKSize(310, 310)),
 					new DpiPath(IconOutputPath, 1.25m, "LargeTile", ".scale-125", new SKSize(310, 310)),
 					new DpiPath(IconOutputPath, 1.50m, "LargeTile", ".scale-150", new SKSize(310, 310)),
 					new DpiPath(IconOutputPath, 2.00m, "LargeTile", ".scale-200", new SKSize(310, 310)),
 					new DpiPath(IconOutputPath, 4.00m, "LargeTile", ".scale-400", new SKSize(310, 310)),
-				};
+				];
 
 			// Badge
-			public static DpiPath[] Badge
-				=> new[]
-				{
+			public static DpiPath[] Badge =>
+				[
 					new DpiPath(IconOutputPath, 1.00m, "Badge", ".scale-100", new SKSize(24, 24)),
 					new DpiPath(IconOutputPath, 1.25m, "Badge", ".scale-125", new SKSize(24, 24)),
 					new DpiPath(IconOutputPath, 1.50m, "Badge", ".scale-150", new SKSize(24, 24)),
 					new DpiPath(IconOutputPath, 2.00m, "Badge", ".scale-200", new SKSize(24, 24)),
 					new DpiPath(IconOutputPath, 4.00m, "Badge", ".scale-400", new SKSize(24, 24)),
-				};
+				];
 
 			// TODO: logo variants (targetsize, altform-unplated, altform-lightunplated)
 
@@ -232,13 +245,13 @@ namespace Uno.Resizetizer
 
 		public static class Wasm
 		{
-			public static DpiPath[] AppIcon => new[]
-			{
+			public static DpiPath[] AppIcon =>
+				[
 					new DpiPath("", 1.00m, scaleSuffix:"-16", size: new SKSize(16, 16)),
 					new DpiPath("", 1.00m,scaleSuffix:"-32", size: new SKSize(32, 32)),
 					new DpiPath("", 1.00m,scaleSuffix:"-128", size: new SKSize(128, 128)),
 					new DpiPath("", 1.00m,scaleSuffix:"-512", size: new SKSize(512, 512)),
-			};
+				];
 		}
 
 		public static DpiPath GetOriginal()
@@ -253,26 +266,15 @@ namespace Uno.Resizetizer
 
 		public static DpiPath[] GetAppIconDpis(string platform, string appIconName)
 		{
-			DpiPath[] result = null;
-
-			switch (platform.ToLowerInvariant())
+			var result = platform.ToLowerInvariant() switch
 			{
-				case "ios":
-				case "maccatalyst":
-					result = DpiPath.Ios.AppIcon;
-					break;
-				case "android":
-					result = DpiPath.Android.AppIcon;
-					break;
-				case "uwp":
-				case "windows":
-				case "wpf":
-					result = DpiPath.Windows.AppIcon;
-					break;
-				case "wasm":
-					result = DpiPath.Wasm.AppIcon;
-					break;
-			}
+				"ios" or "maccatalyst" => Ios.AppIcon,
+				"android" => Android.AppIcon,
+				"wpf" when RuntimeInformation.IsOSPlatform(OSPlatform.OSX) => MacOS.AppIcon,
+				"uwp" or "windows" or "wpf" => Windows.AppIcon,
+				"wasm" => Wasm.AppIcon,
+				_ => throw new PlatformNotSupportedException(),
+			};
 
 			foreach (var r in result)
 			{

--- a/src/Resizetizer/src/Resizer.cs
+++ b/src/Resizetizer/src/Resizer.cs
@@ -30,7 +30,11 @@ namespace Uno.Resizetizer
 			var platform = Environment.OSVersion.Platform;
 
 			string path;
-			if (platform == PlatformID.MacOSX)
+			if (dpi.Path.EndsWith(".appiconset", StringComparison.InvariantCultureIgnoreCase))
+			{
+				path = string.Empty;
+			}
+			else if (platform == PlatformID.MacOSX)
 			{
 				path = Path.GetFullPath(info.OutputPath);
 			}

--- a/src/Resizetizer/src/ResizetizeImages.cs
+++ b/src/Resizetizer/src/ResizetizeImages.cs
@@ -183,7 +183,7 @@ namespace Uno.Resizetizer
 			}
 			else if (PlatformType == "ios" || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && TargetFramework.Equals("desktop", StringComparison.InvariantCultureIgnoreCase)))
 			{
-				var logMessage = PlatformType == "ios" ? "iOS Icon Assets Generator" : "MacOS Icon Assets Generator";
+				var logMessage = !TargetFramework.Equals("desktop", StringComparison.InvariantCultureIgnoreCase) ? "iOS Icon Assets Generator" : "MacOS Icon Assets Generator";
 				LogDebugMessage(logMessage);
 
 				var appleAssetGen = new AppleIconAssetsGenerator(img, appIconName, IntermediateOutputPath, appIconDpis, this);

--- a/src/Resizetizer/src/ResizetizeImages.cs
+++ b/src/Resizetizer/src/ResizetizeImages.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Uno.Resizetizer
 {
@@ -147,7 +148,7 @@ namespace Uno.Resizetizer
 				copiedResources.Add(taskItem);
 			}
 
-			CopiedResources = copiedResources.ToArray();
+			CopiedResources = [.. copiedResources];
 
 			return System.Threading.Tasks.Task.CompletedTask;
 		}
@@ -178,11 +179,12 @@ namespace Uno.Resizetizer
 					androidAppIcons.Add(new TaskItem(iconGenerated.Filename));
 				}
 
-				AndroidAppIcons = androidAppIcons.ToArray();
+				AndroidAppIcons = [.. androidAppIcons];
 			}
-			else if (PlatformType == "ios")
+			else if (PlatformType == "ios" || (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && TargetFramework.Equals("desktop", StringComparison.InvariantCultureIgnoreCase)))
 			{
-				LogDebugMessage($"iOS Icon Assets Generator");
+				var logMessage = PlatformType == "ios" ? "iOS Icon Assets Generator" : "MacOS Icon Assets Generator";
+				LogDebugMessage(logMessage);
 
 				var appleAssetGen = new AppleIconAssetsGenerator(img, appIconName, IntermediateOutputPath, appIconDpis, this);
 

--- a/src/Resizetizer/src/Resizetizer.csproj
+++ b/src/Resizetizer/src/Resizetizer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -65,11 +65,11 @@
 	<ItemGroup>
 		<None Include="../../../README.md" Pack="true" PackagePath="/" />
 
-		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.targets" Visible="false" Pack="true" PackagePath="build/$(PackageId).targets" CopyToOutputDirectory="PreserveNewest" />
-		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.android.targets" Visible="false" Pack="true" PackagePath="build/$(PackageId).android.targets" CopyToOutputDirectory="PreserveNewest" />
-		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.apple.targets" Visible="false" Pack="true" PackagePath="build/$(PackageId).apple.targets" CopyToOutputDirectory="PreserveNewest" />
-		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.wasm.targets" Visible="false" Pack="true" PackagePath="build/$(PackageId).wasm.targets" CopyToOutputDirectory="PreserveNewest" />
-		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.windows.skia.targets" Visible="false" Pack="true" PackagePath="build/$(PackageId).windows.skia.targets" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.targets" LinkBase="build" Pack="true" PackagePath="build/$(PackageId).targets" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.android.targets" LinkBase="build" Pack="true" PackagePath="build/$(PackageId).android.targets" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.apple.targets" LinkBase="build" Pack="true" PackagePath="build/$(PackageId).apple.targets" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.wasm.targets" LinkBase="build" Pack="true" PackagePath="build/$(PackageId).wasm.targets" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="$(UnoNuspecDirectory)Uno.Resizetizer.windows.skia.targets" LinkBase="build" Pack="true" PackagePath="build/$(PackageId).windows.skia.targets" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 
 	<Import Project="../Directory.UnoMetadata.targets" />

--- a/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -360,9 +360,9 @@ namespace Uno.Resizetizer.Tests
 				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
 
 				var fn = filename.Replace("camera.", "", StringComparison.OrdinalIgnoreCase);
-				AssertFileMatches($"mipmap-mdpi/camera.png", new object[] { fn, colorString, tintColorString, "m", "i" });
-				AssertFileMatches($"mipmap-mdpi/camera_background.png", new object[] { fn, colorString, tintColorString, "m", "b" });
-				AssertFileMatches($"mipmap-mdpi/camera_foreground.png", new object[] { fn, colorString, tintColorString, "m", "f" });
+				AssertFileMatches($"mipmap-mdpi/camera.png", [fn, colorString, tintColorString, "m", "i"]);
+				AssertFileMatches($"mipmap-mdpi/camera_background.png", [fn, colorString, tintColorString, "m", "b"]);
+				AssertFileMatches($"mipmap-mdpi/camera_foreground.png", [fn, colorString, tintColorString, "m", "f"]);
 			}
 
 			[Theory]

--- a/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -19,6 +19,7 @@ namespace Uno.Resizetizer.Tests
 			protected ResizetizeImages_v0 GetNewTask(string type, params ITaskItem[] items) =>
 				new ResizetizeImages_v0
 				{
+					TargetFramework = type ?? string.Empty,
 					PlatformType = type,
 					IntermediateOutputPath = DestinationDirectory,
 					IntermediateOutputIconPath = DestinationDirectory,


### PR DESCRIPTION
Fixes: #

- fixes #301

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

When generating the App Icon for the Desktop target on MacOS we continue to generate the Windows/WPF app icons

## What is the new behavior?

When generating the App Icon for the Desktop target on MacOS we now intercept this and generate an AppIconSet that can be properly used when we package the application.