### PR TITLE
feat: Allow disabling the icon background

### DIFF
--- a/doc/uno-resizetizer-properties.md
+++ b/doc/uno-resizetizer-properties.md
@@ -26,16 +26,17 @@ Properties that can be used across all items
 
 ## UnoIcon
 
-| Property Name            | Description                                                                                                                           |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `Include`                | Used to insert the path of the Background image.                                                                                      |
-| `ForegroundFile`         | Used to insert the path of the Foreground image                                                                                       |
-| `ForegroundScale`        | Used to rescale the Foreground image, in order to fit on the app icon, it's a percentage value so `0.33` will be translated as 33%.   |
-| `AndroidForegroundScale` | The same as ForegroundScale, but the value will be applied just for Android.                                                          |
-| `WasmForegroundScale`    | The same as ForegroundScale, but the value will be applied just for Wasm                                                              |
-| `WindowsForegroundScale` | The same as ForegroundScale, but the value will be applied just for Windows                                                           |
-| `IOSForegroundScale`     | The same as ForegroundScale, but the value will be applied just for iOS                                                               |
-| `SkiaForegroundScale`    | The same as ForegroundScale, but the value will be applied just for Skia targets                                                      |
+| Property Name            | Description                                                                                                                                 |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `Include`                | Used to insert the path of the Background image.                                                                                            |
+| `ForegroundFile`         | Used to insert the path of the Foreground image                                                                                             |
+| `ForegroundScale`        | Used to rescale the Foreground image, in order to fit on the app icon, it's a percentage value so `0.33` will be translated as 33%.         |
+| `UseBackgroundFile`      | If set to `false`, only the foreground image will be used with a transparent background. Defaults to `true` on desktop, `false` elsewhere.  |
+| `AndroidForegroundScale` | The same as ForegroundScale, but the value will be applied just for Android.                                                                |
+| `WasmForegroundScale`    | The same as ForegroundScale, but the value will be applied just for Wasm                                                                    |
+| `WindowsForegroundScale` | The same as ForegroundScale, but the value will be applied just for Windows                                                                 |
+| `IOSForegroundScale`     | The same as ForegroundScale, but the value will be applied just for iOS                                                                     |
+| `SkiaForegroundScale`    | The same as ForegroundScale, but the value will be applied just for Skia targets                                                            |
 
 > [!NOTE]
 > The `<PLATFORM>ForegroundScale` (`AndroidForegroundScale`, `WasmForegroundScale`, etc) will override the global `ForegroundScale` value.

--- a/doc/using-uno-resizetizer.md
+++ b/doc/using-uno-resizetizer.md
@@ -109,6 +109,7 @@ The Uno Platform SDK exposes several properties that simplify the customization 
 * `UnoIconForegroundFile`: Sets the foreground image file for the icon.
 * `UnoIconForegroundScale`: Adjusts the scaling of the icon's foreground.
 * `UnoIconBackgroundColor`: Sets the background color of the icon.
+* `UnoUseIconBackgroundFile`: Controls whether the background file is used (useful for platforms where icons can have transparent background, e.g. desktop).
 
 For basic adjustments, such as changing the icon's foreground color or applying a common modification across platforms, you can use SDK properties:
 
@@ -362,6 +363,7 @@ Next, some adjustments are needed on `Android`, `Windows`, and `iOS`.
 -----
 
 ## Platform-Specific Customization
+
 The Uno Resizetizer SDK allows for detailed control over how assets are rendered on different platforms. This can be particularly useful for properties such as icon and splash screen backgrounds, which may need to vary between platforms due to design or visibility concerns.
 
 ### Customizing Background Colors Per Platform
@@ -382,7 +384,7 @@ For properties like BackgroundColor, which might need different values per platf
 ```
 This setup demonstrates setting a default background color that is overridden on specific platforms. Adjust the conditions to match your project's target frameworks as defined in your project files or SDK documentation.
 
-#### Applying Platform-Specific Scale
+### Applying Platform-Specific Scale
 Similarly, if you want to apply different scaling factors for the icon foreground across platforms, use the platform-specific properties:
 
 ```xml

--- a/src/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/Resizetizer/src/ResizeImageInfo.cs
@@ -50,7 +50,7 @@ namespace Uno.Resizetizer
 
 		public bool IsAppIcon { get; set; }
 
-		public bool UseIconBackground { get; set; } = true;
+		public bool UseBackgroundFile { get; set; } = true;
 
 		public bool IsSplashScreen { get; set; }
 
@@ -140,9 +140,9 @@ namespace Uno.Resizetizer
 					info.ForegroundScale = fsc;
 				}
 
-				if (bool.TryParse(image.GetMetadata(nameof(UseIconBackground)), out var uib))
+				if (bool.TryParse(image.GetMetadata(nameof(UseBackgroundFile)), out var uib))
 				{
-					info.UseIconBackground = uib;
+					info.UseBackgroundFile = uib;
 				}
 
 				if (info.IsSplashScreen)
@@ -163,7 +163,7 @@ namespace Uno.Resizetizer
 					info.ForegroundFilename = fgFileInfo.FullName;
 
 					// If we don't want to apply icon background, we set it to null.
-					if (!info.UseIconBackground)
+					if (!info.UseBackgroundFile)
 					{
 						info.Filename = null;
 					}

--- a/src/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/Resizetizer/src/ResizeImageInfo.cs
@@ -50,6 +50,8 @@ namespace Uno.Resizetizer
 
 		public bool IsAppIcon { get; set; }
 
+		public bool UseIconBackground { get; set; }
+
 		public bool IsSplashScreen { get; set; }
 
 		public string? ForegroundFilename { get; set; }
@@ -138,7 +140,12 @@ namespace Uno.Resizetizer
 					info.ForegroundScale = fsc;
 				}
 
-				if (info.IsSplashScreen)
+                if (bool.TryParse(image.GetMetadata(nameof(UseIconBackground)), out var uib))
+                {
+                    info.UseIconBackground = uib;
+                }
+
+                if (info.IsSplashScreen)
 				{
 					SetPlatformForegroundScale(image, "Scale", info);
 					ApplyPlatformScale(image, info);
@@ -154,6 +161,12 @@ namespace Uno.Resizetizer
 					}
 
 					info.ForegroundFilename = fgFileInfo.FullName;
+
+					// If we don't want to apply icon background, we set it to null.
+					if (!info.UseIconBackground)
+					{
+						info.Filename = null;
+					}
 				}
 
 				if (info.IsAppIcon)

--- a/src/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/Resizetizer/src/ResizeImageInfo.cs
@@ -50,7 +50,7 @@ namespace Uno.Resizetizer
 
 		public bool IsAppIcon { get; set; }
 
-		public bool UseIconBackground { get; set; }
+		public bool UseIconBackground { get; set; } = true;
 
 		public bool IsSplashScreen { get; set; }
 

--- a/src/Resizetizer/src/ResizeImageInfo.cs
+++ b/src/Resizetizer/src/ResizeImageInfo.cs
@@ -140,12 +140,12 @@ namespace Uno.Resizetizer
 					info.ForegroundScale = fsc;
 				}
 
-                if (bool.TryParse(image.GetMetadata(nameof(UseIconBackground)), out var uib))
-                {
-                    info.UseIconBackground = uib;
-                }
+				if (bool.TryParse(image.GetMetadata(nameof(UseIconBackground)), out var uib))
+				{
+					info.UseIconBackground = uib;
+				}
 
-                if (info.IsSplashScreen)
+				if (info.IsSplashScreen)
 				{
 					SetPlatformForegroundScale(image, "Scale", info);
 					ApplyPlatformScale(image, info);


### PR DESCRIPTION
Part of: https://github.com/unoplatform/uno.resizetizer/issues/190

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Currently the user must create a new `.svg` file like `icon_transparent.svg` that is empty and provide it as the `UnoIconBackgroundFile` - as leaving this empty will fallback to `icon.svg`. 


## What is the new behavior?

New attribute allows setting `UseIconBackground` to `false`, which will not use the background file while generating, and will keep the foreground file only instead.

### **I made a follow up PR https://github.com/unoplatform/uno/pull/17855 in Uno.UI to add a prop to control this and then default this to `false` on WASM, desktop and WinUI, where users most commonly don't want a background behind the icon.**


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
