### PR TITLE
fix: Fix invalid namespace on HR

### DIFF
--- a/src/Resizetizer/Resizetizer.Generators/WindowTitleGenerator.cs
+++ b/src/Resizetizer/Resizetizer.Generators/WindowTitleGenerator.cs
@@ -17,14 +17,15 @@ internal sealed class WindowTitleGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // To avoid breaking existing applications, we add a legacy namespace compat class.
-        // We make sure to add it for all compilation (including for HR compilations!) without any filter.
-        context.RegisterSourceOutput(context.CompilationProvider, (srcCtx, _) => AddSource(srcCtx, GenerateLegacyNamespaceCompat()));
 
         // Get the AnalyzerConfigOptionsProvider
         var optionsProvider = context.AnalyzerConfigOptionsProvider;
         var assemblyNameProvider = context.CompilationProvider.Select((compilation, _) => compilation.Assembly.Name);
         var additionalTextsProvider = context.AdditionalTextsProvider;
+
+        // To avoid breaking existing applications, we add a legacy namespace compat class.
+        // We make sure to add it for all compilation (including for HR compilations!) without any filter (other than assembly name to reduce load).
+        context.RegisterSourceOutput(assemblyNameProvider, (srcCtx, _) => AddSource(srcCtx, GenerateLegacyNamespaceCompat()));
 
         var extensionPropertiesProvider = optionsProvider.Combine(assemblyNameProvider).Select((x, cancellationToken) =>
         {


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/20926

## Bugfix
Invalid namespace on HR

## What is the current behavior?
Cannot HR

## What is the new behavior?
🙃

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
