### PR TITLE
chore: add embedded-resource for splashscreen definition

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -451,6 +451,14 @@
 	<!-- This target is meant to be called by platform specific splash screen targets -->
 	<Target Name="GenerateUnoSplashScreens"
 			Condition="'@(UnoSplashScreen)' != ''">
+		<!-- Resource used by (toolkit) ExtendedSplashScreen -->
+		<PropertyGroup>
+			<_UnoSplashDef>$(IntermediateOutputPath)UnoSplash2.def</_UnoSplashDef>
+		</PropertyGroup>
+		<WriteLinesToFile File="$(_UnoSplashDef)" Lines="@(UnoSplashScreen->'File=%(Identity);Link=%(Link);BaseSize=%(BaseSize);Resize=%(Resize);TintColor=%(TintColor);Color=%(Color);ForegroundScale=%(ForegroundScale)')" Overwrite="true" WriteOnlyWhenDifferent="true" />
+		<ItemGroup>
+			<EmbeddedResource Include="$(_UnoSplashDef)" LogicalName="UnoSplash2.def" />
+		</ItemGroup>
 
 		<!--If not Windows-->
 		<ItemGroup Condition="$(_UnoResizetizerIsWasmApp) == 'True' Or $(_UnoResizetizerIsSkiaApp) == 'True' or '$(_UnoResizetizerIsAndroidApp)' == 'True' or ('$(_UnoResizetizerIsiOSApp)' == 'True' and '$(TargetPlatformIdentifier)' != 'maccatalyst')">


### PR DESCRIPTION
re: unoplatform/uno.toolkit.ui#1404

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
on mobile platforms, there is currently no way to retrieve the splash-screen image and background.

## What is the new behavior?
an EmbeddedResource is now added that describes the screen-screen, which can be loaded by the app at runtime.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->