### PR TITLE
ci: Move to dotnet-sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,11 @@ jobs:
     name: Sign
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
     runs-on: windows-latest
+    environment: PackageSign
+
+    permissions:
+      id-token: write # Required for requesting the JWT
+
     needs:
       - build_tool
       - validation_5_6_win
@@ -238,15 +243,34 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.100'
+          dotnet-version: '9.0.x'
 
-      - name: Setup SignClient
-        run: |
-          dotnet tool install --tool-path build SignClient
-      - name: SignClient
+      # Install the code signing tool    
+      - name: Install Sign CLI tool
+        run: dotnet tool install --tool-path . sign --version 0.9.1-beta.25278.1
+      
+      # Login to Azure using a ServicePrincipal configured to authenticate against a GitHub Action
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          allow-no-subscriptions: true
+          client-id: ${{ secrets.SIGN_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.SIGN_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.SIGN_AZURE_SUBSCRIPTION_ID }}
+
+      # Run the signing command
+      - name: Sign artifacts
         shell: pwsh
-        run: |
-          build\SignClient sign -i artifacts\*.nupkg -c build\SignClient.json -r "${{ secrets.UNO_PLATFORM_CODESIGN_USERNAME }}" -s "${{ secrets.UNO_PLATFORM_CODESIGN_SECRET }}" -n "uno.resizetizer" -d "uno.resizetizer" -u "https://github.com/unoplatform/uno.resizetizer"
+        run: >
+          ./sign code azure-key-vault
+          artifacts\NuGet\*.nupkg
+          --publisher-name "Uno.Resizetizer"
+          --description "Uno.Resizetizer"
+          --description-url "https://github.com/${{ env.GITHUB_REPOSITORY }}"
+          --azure-key-vault-managed-identity true
+          --azure-key-vault-url "${{ secrets.SIGN_KEY_VAULT_URL }}"
+          --azure-key-vault-certificate "${{ secrets.SIGN_KEY_VAULT_CERTIFICATE_ID }}"
+          --verbosity information
 
       - name: Upload Signed Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Move to dotnet-sign and not use the legacy signing service anymore
