### PR TITLE
Version bump after 1.10 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.10-dev.{height}",
+  "version": "1.11-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Move to dotnet-sign and not use the legacy signing service anymore

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/1.10, based on #350