### PR TITLE
fix(ios): resizetized images not using ios naming convention

### DIFF
--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -85,6 +85,7 @@
 		<_UnoResizetizerPlatformIsmacOS Condition="'$(_UnoResizetizerPlatformIdentifier)' == 'macos'">True</_UnoResizetizerPlatformIsmacOS>
 		<_UnoResizetizerPlatformIstvOS Condition="'$(_UnoResizetizerPlatformIdentifier)' == 'tvos'">True</_UnoResizetizerPlatformIstvOS>
 		<_UnoResizetizerPlatformIsWindows Condition="$(_UnoResizetizerPlatformIdentifier.Contains('windows')) == 'True'">True</_UnoResizetizerPlatformIsWindows>
+		<_UnoResizetizerSkiaRenderer Condition="$(UnoFeatures.Contains(';skiarenderer;'))">True</_UnoResizetizerSkiaRenderer>
 
 		<UnoResizetizerIncludeSelfProject Condition="'$(UnoResizetizerIncludeSelfProject)' == ''">False</UnoResizetizerIncludeSelfProject>
 
@@ -189,6 +190,11 @@
 			UnoAssetsGeneration;
 			_CollectBundleResources;
 			_BeforeCoreCompileImageAssets;
+		</UnoResizetizeBeforeTargets>
+		<!-- Allow resizetized Content to be re-targeted for native-ios -->
+		<UnoResizetizeBeforeTargets Condition="'$(_UnoResizetizerSkiaRenderer)' != 'True'">
+			$(UnoResizetizeBeforeTargets);
+			AssignTargetPaths;
 		</UnoResizetizeBeforeTargets>
 
 		<CollectBundleResourcesDependsOn>


### PR DESCRIPTION
Fixes: unoplatform/uno#21291

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS, resizetized images are bundled into the application with the windows naming convention of `.scale-NNN` rather than iOS' `@Nx`. This causes the app to always load the image at lowest resolution on native-ios.

## What is the new behavior?
Adjusted the targets order, so the resulting resizetized images will be picked up by RetargetAssets.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
RetargetAssets target uses ContentWithTargetPath for inputs, not Content. ContentWithTargetPath is mapped from Content in AssignTargetPaths target.