### PR TITLE
fix: Don't fail on disabled PWA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,18 @@ jobs:
           8.0.x
           9.0.100
 
+    - run: |
+        & dotnet tool update --global uno.check --version ${{ env.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
+        & uno-check -v --ci --non-interactive --fix --skip xcode --skip androidemulator --skip gtk3 --skip vswin --skip vsmac
+      shell: pwsh
+      name: Install .NET Workloads
+
     - name: Download Artifact
       uses: actions/download-artifact@v4
       with:
         name: NuGet
         path: samples/packages
-        
+
     - name: Validate 5.6 Sample app (Debug - DesignTimeBuild)
       run: |
         $installationPath = vswhere -latest -property installationPath

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: |
+          8.0.x
+          9.0.100
 
     - run: |
         ubuntu_release=`lsb_release -rs`
@@ -184,7 +186,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: |
+          8.0.x
+          9.0.100
 
     - name: Download Artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,12 @@ jobs:
       run: |
         & dotnet build -c ${{ matrix.config }} -p:RunAOTCompilation=false -p:WasmShellILLinkerEnabled=false /p:WindowsAppSDKSelfContained=false /p:WindowsPackageType=None -bl:./logs/sample-5.6-${{ matrix.config }}.binlog samples/5.6/Uno52ResizetizerTests/Uno52ResizetizerTests.sln
   
+    - name: Validate PWA disabled (WasmPWAManifestFile stays empty)
+      shell: pwsh
+      if: matrix.os != 'macos-latest' || matrix.config != 'Release'
+      run: |
+        & dotnet build -c ${{ matrix.config }} -p:TargetFramework=net9.0-browserwasm -p:WasmPWAManifestFile= -p:_ValidateNoPwa=true -p:RunAOTCompilation=false -p:WasmShellILLinkerEnabled=false -bl:./logs/sample-5.6-${{ matrix.config }}-pwa-disabled.binlog samples/5.6/Uno52ResizetizerTests/Uno52ResizetizerTests/Uno52ResizetizerTests.csproj
+
     - name: Validate 5.6 Samples app (${{ matrix.config }} Incremental)
   
       # Skip the macOS release build, the agent does not have 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
 env:
   UnoCheck_Version: '1.28.3'
   DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
+  DOTNET_ROOT: ${{ github.workspace }}/.dotnet
+  DOTNET_MULTILEVEL_LOOKUP: '0'
 
 jobs:
   build_tool:
@@ -29,7 +31,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.100'
+        dotnet-version: |
+          8.0.x
+          9.0.100
 
     - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
       id: nbgv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   UnoCheck_Version: '1.28.3'
+  DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
 
 jobs:
   build_tool:

--- a/samples/5.6/Uno52ResizetizerTests/Uno52ResizetizerTests/Uno52ResizetizerTests.csproj
+++ b/samples/5.6/Uno52ResizetizerTests/Uno52ResizetizerTests/Uno52ResizetizerTests.csproj
@@ -47,4 +47,12 @@
     <Error Condition="!Exists('$(OutputPath)\Assets\Icons\back.scale-100.png')" Text="back.scale-100.png file wasn't created." />
   </Target>
 
+  <!-- Validates that WasmPWAManifestFile stays empty when PWA is disabled (no manifest file present).
+       Triggered by passing /p:_ValidateNoPwa=true to the build. -->
+  <Target Name="ValidatePwaDisabled" AfterTargets="ProcessResizedImagesWasm" Condition="'$(_ValidateNoPwa)' == 'true'">
+    <Error Condition="'$(WasmPWAManifestFile)' != ''"
+           Text="WasmPWAManifestFile should be empty when PWA is disabled, but was '$(WasmPWAManifestFile)'" />
+    <Message Text="ValidatePwaDisabled: WasmPWAManifestFile is correctly empty." Importance="high" />
+  </Target>
+
 </Project>

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -526,7 +526,7 @@
 
 		<PropertyGroup>
 			<!-- If the PWA manifest is empty we can try to find it on disk -->
-			<_UnoResizetizerPwaManifest>$(_UnoIntermediateAppIcon)..\$([System.IO.Path]::GetFileName($(WasmPWAManifestFile)))</_UnoResizetizerPwaManifest>
+			<_UnoResizetizerPwaManifest Condition="'$(WasmPWAManifestFile)' != ''">$(_UnoIntermediateAppIcon)..\$([System.IO.Path]::GetFileName($(WasmPWAManifestFile)))</_UnoResizetizerPwaManifest>
 			<UnoResizetizerPwaManifest Condition="
 				'$(UnoResizetizerPwaManifest)'=='' and
 				Exists('$(_UnoResizetizerPwaManifest)')">$(_UnoResizetizerPwaManifest)</UnoResizetizerPwaManifest>


### PR DESCRIPTION
Don't fail the build when `WasmPWAManifestFile` is not set.