### PR TITLE
Log a clear error instead of MSB4181 when the WASM splash has no AppManifest.js

### DIFF
--- a/src/Resizetizer/src/GenerateWasmSplashAssets.cs
+++ b/src/Resizetizer/src/GenerateWasmSplashAssets.cs
@@ -38,7 +38,7 @@ public class GenerateWasmSplashAssets_v0 : Task
 #endif
 		if (UnoSplashScreen is null || UnoSplashScreen.Length is 0 )
 		{
-			Log.LogWarning("Didn't find UnoSplashScreen.");
+			Log.LogMessage(MessageImportance.Low, "No UnoSplashScreen item is configured; skipping WebAssembly splash screen generation.");
 			return true;
 		}
 
@@ -56,7 +56,9 @@ public class GenerateWasmSplashAssets_v0 : Task
 
 		if (UserAppManifest is null)
 		{
-			Log.LogWarning("Didn't find AppManifest.js file.");
+			// Log an error, not a warning: this method returns false, and MSBuild treats "task returned
+			// false without logging an error" as the opaque MSB4181. A clear message tells the user how to fix it.
+			Log.LogError("A WebAssembly splash screen is configured (a UnoSplashScreen item is present), but the required AppManifest.js embedded resource was not found. To generate the splash screen, add an AppManifest.js at Platforms/WebAssembly/WasmScripts/AppManifest.js (see https://platform.uno/docs/articles/wasm-appmanifest.html for its expected contents). If a WebAssembly splash screen is not needed, remove the UnoSplashScreen item instead.");
 			return false;
 		}
 


### PR DESCRIPTION
## Problem

When a WebAssembly head has a `UnoSplashScreen` configured but no `AppManifest.js` embedded resource, the build fails with the opaque:

```
error MSB4181: The "GenerateWasmSplashAssets" task returned false but did not log an error.
```

That message gives no hint about the actual cause. It happens whenever a project has a splash screen but no WASM `AppManifest.js` — for example a single-project app scaffolded for other heads first, where `Platforms/WebAssembly/WasmScripts/AppManifest.js` was never created.

## Root cause

In that case `GenerateWasmSplashAssets.Execute()` returns `false` while logging only a warning, not an error. MSBuild's contract is that a task returning `false` must log an error; when it only logs a warning, the engine raises the generic MSB4181 and the real reason is lost.

## Fix

Log an error with an actionable message so the developer knows exactly how to resolve it:

- add `Platforms/WebAssembly/WasmScripts/AppManifest.js` (see https://platform.uno/docs/articles/wasm-appmanifest.html for its expected contents), or
- remove the `UnoSplashScreen` item if a WebAssembly splash screen isn't wanted.

The requirement itself is unchanged — an `AppManifest.js` is genuinely needed to inject the WASM splash; only the diagnostic is clarified.

## Also in this PR

The neighbouring "no `UnoSplashScreen` configured" branch logged a terse warning and returned `true`. Since that is a normal skip (there is nothing to generate), it is lowered to a low-importance message with clearer wording, so it no longer surfaces as a build warning for projects that simply don't use a WASM splash.

## Notes

Found while adding a WebAssembly head to an existing single-project app. Happy to adjust the wording or approach.

