### PR TITLE
docs: Replace dropped Gtk/WPF Skia targets with Skia Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uno.Resizetizer
 
-Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, mac Catalyst, Gtk/WPF and WebAssembly target.
+Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, mac Catalyst, Skia Desktop and WebAssembly target.
 
 [![NuGet](https://badgen.net/nuget/v/Uno.Resizetizer)](https://www.nuget.org/packages/Uno.Resizetizer)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uno.Resizetizer
 
-Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, Mac Catalyst, Skia Desktop, and WebAssembly.
+Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, Skia Desktop, and WebAssembly.
 
 [![NuGet](https://badgen.net/nuget/v/Uno.Resizetizer)](https://www.nuget.org/packages/Uno.Resizetizer)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uno.Resizetizer
 
-Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, Skia Desktop, and WebAssembly.
+Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, Mac Catalyst, Skia Desktop, and WebAssembly.
 
 [![NuGet](https://badgen.net/nuget/v/Uno.Resizetizer)](https://www.nuget.org/packages/Uno.Resizetizer)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uno.Resizetizer
 
-Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, mac Catalyst, Skia Desktop and WebAssembly target.
+Based on [the work](https://github.com/Redth/Resizetizer) from [@redth](https://github.com/Redth) from the .NET team, Uno.Resizetizer uses SVG and PNG files to generate images for all resolutions needed for your .NET 6+ apps. It is available for applications running with [Uno Platform](https://github.com/unoplatform/uno) on iOS, Android, Mac Catalyst, Skia Desktop, and WebAssembly.
 
 [![NuGet](https://badgen.net/nuget/v/Uno.Resizetizer)](https://www.nuget.org/packages/Uno.Resizetizer)
 

--- a/doc/uno-resizetizer-properties.md
+++ b/doc/uno-resizetizer-properties.md
@@ -56,4 +56,4 @@ Properties that can be used across all items
 | `IOSScale`     | Used to scale the image that will be used as SplashScreen on iOS platform.                                                  |
 | `WindowsScale` | Used to scale the image that will be used as SplashScreen on Windows platform.                                              |
 | `WasmScale`    | Used to scale the image that will be used as SplashScreen on Wasm.                                                          |
-| `SkiaScale`    | Used to scale the image that will be used as SplashScreen on Skia targets (Win32, X11, and macOS).                                    |
+| `SkiaScale`    | Used to scale the image that will be used as SplashScreen on Skia targets (Win32, X11, and macOS).                          |

--- a/doc/uno-resizetizer-properties.md
+++ b/doc/uno-resizetizer-properties.md
@@ -56,4 +56,4 @@ Properties that can be used across all items
 | `IOSScale`     | Used to scale the image that will be used as SplashScreen on iOS platform.                                                  |
 | `WindowsScale` | Used to scale the image that will be used as SplashScreen on Windows platform.                                              |
 | `WasmScale`    | Used to scale the image that will be used as SplashScreen on Wasm.                                                          |
-| `SkiaScale`    | Used to scale the image that will be used as SplashScreen on Skia targets (GTK and WPF).                                    |
+| `SkiaScale`    | Used to scale the image that will be used as SplashScreen on Skia targets (Win32, X11, and macOS).                                    |


### PR DESCRIPTION
## What changed?

📚 Documentation content changes

Two docs referred to the dropped **Skia GTK** (removed in Uno 6.0) and **Skia WPF** (removed in Uno 6.6) runtimes as current Skia targets:

- `README.md` — "…mac Catalyst, **Gtk/WPF** and WebAssembly" → "…Mac Catalyst, **Skia Desktop**, and WebAssembly" (also minor grammar: "Mac Catalyst" capitalization, Oxford comma).
- `doc/uno-resizetizer-properties.md` — `SkiaScale` now refers to the current Skia Desktop backends **(Win32, X11, and macOS)** instead of the dropped **GTK and WPF**.

Docs-only. The resizetizer tool does **not** branch on the WPF head — the internal `"wpf"` platform-type label is a legacy alias covering the whole Skia desktop family — so the drops require no functional code change.

> Note: Mac Catalyst is **not** dropped — the upstream removal (unoplatform/uno#23347) was reverted (unoplatform/uno#23421), so it stays in the platform list.

## Related to the dropped targets

- **WPF drop**: unoplatform/uno#23260 (issue) · unoplatform/uno#23261 (PR)
- **GTK drop**: unoplatform/uno#19752 (PR)
