### PR TITLE
Add monochrome icon support for Android

### DIFF
--- a/src/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
+++ b/src/Resizetizer/src/AndroidAdaptiveIconGenerator.cs
@@ -27,6 +27,7 @@ namespace Uno.Resizetizer
 <adaptive-icon xmlns:android=""http://schemas.android.com/apk/res/android"">
 	<background android:drawable=""@mipmap/{name}_background""/>
 	<foreground android:drawable=""@mipmap/{name}_foreground""/>
+	<monochrome android:drawable=""@mipmap/{name}_foreground"" />
 </adaptive-icon>";
 
 		public IEnumerable<ResizedImageInfo> Generate()


### PR DESCRIPTION
Fixes: #372

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Adaptive Icons generated don't have monochrome entry in them.

## What is the new behavior?

Monochrome entries are added to the generated output.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->