### PR TITLE
Enhanced ICO Generation

### DIFF
--- a/src/Resizetizer/src/Utils.cs
+++ b/src/Resizetizer/src/Utils.cs
@@ -73,7 +73,17 @@ namespace Uno.Resizetizer
 			logger.Log($"Generating ICO: {destination}");
 
 			var tools = new SkiaSharpAppIconTools(info, logger);
-			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(64, 64));
+			var dpi = new DpiPath(fileName, 1.0m, size: new SKSize(256, 256));
+			var sizes = new[] { 16, 24, 32, 48, 64, 128, 256 };
+			var entries = new (int Size, byte[] Data)[sizes.Length];
+			for (var i = 0; i < sizes.Length; i++)
+			{
+				var size = sizes[i];
+				dpi = new DpiPath(fileName, 1.0m, size: new SKSize(size, size));
+				using var memoryStream = new MemoryStream();
+				tools.Resize(dpi, destination, () => memoryStream);
+				entries[i] = (size, memoryStream.ToArray());
+			}
 
 			if (destinationModified > sourceModified)
 			{
@@ -81,32 +91,34 @@ namespace Uno.Resizetizer
 				return new ResizedImageInfo { Dpi = dpi, Filename = destination };
 			}
 
-			MemoryStream memoryStream = new MemoryStream();
-			tools.Resize(dpi, destination, () => memoryStream);
-			memoryStream.Position = 0;
-
-			int numberOfImages = 1;
 			using BinaryWriter writer = new BinaryWriter(File.Create(destination));
 			writer.Write((short)0x0); // Reserved. Must always be 0.
 			writer.Write((short)0x1); // Specifies image type: 1 for icon (.ICO) image
-			writer.Write((short)numberOfImages); // Specifies number of images in the file.
+			writer.Write((short)entries.Length); // Specifies number of images in the file.
 
-			writer.Write((byte)dpi.Size.Value.Width);
-			writer.Write((byte)dpi.Size.Value.Height);
-			writer.Write((byte)0x0); // Specifies number of colors in the color palette
-			writer.Write((byte)0x0); // Reserved. Should be 0
-			writer.Write((short)0x1); // Specifies color planes. Should be 0 or 1
-			writer.Write((short)0x8); // Specifies bits per pixel.
-			writer.Write((int)memoryStream.Length); // Specifies the size of the image's data in bytes
+			var offset = 6 + (16 * entries.Length);
+			foreach (var (size, data) in entries)
+			{
+				var normalizedSize = size == 256 ? 0 : size;
+				writer.Write((byte)normalizedSize); // Width in pixels, 0 means 256
+				writer.Write((byte)normalizedSize); // Height in pixels, 0 means 256
+				writer.Write((byte)0x0); // Specifies number of colors in the color palette
+				writer.Write((byte)0x0); // Reserved. Should be 0
+				writer.Write((short)0x1); // Specifies color planes. Should be 0 or 1
+				writer.Write((short)0x20); // Specifies bits per pixel, 32 for PNG data
+				writer.Write(data.Length); // Specifies the size of the image's data in bytes
+				writer.Write(offset); // Specifies the offset of PNG data from the beginning of the ICO/CUR file
+				offset += data.Length;
+			}
 
-			int offset = 6 + (16 * numberOfImages); // + length of previous images
-			writer.Write(offset); // Specifies the offset of BMP or PNG data from the beginning of the ICO/CUR file
+			foreach (var (_, data) in entries)
+			{
+				writer.Write(data);
+			}
 
-			// write png data for each image
-			memoryStream.CopyTo(writer.BaseStream);
 			writer.Flush();
 
-			return new ResizedImageInfo { Dpi = dpi, Filename = destination };
+			return new ResizedImageInfo { Dpi = new DpiPath(fileName, 1.0m, size: new SKSize(256, 256)), Filename = destination };
 		}
 
 		public static string SkiaColorWithoutAlpha(SKColor? skColor)

--- a/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -771,6 +771,56 @@ namespace Uno.Resizetizer.Tests
 			}
 
 			[Fact]
+			public void AppIconGeneratesIcoFile()
+			{
+				var items = new[]
+				{
+					new TaskItem("images/camera.png", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				Assert.NotNull(task.GeneratedIconPath);
+				var generatedIcon = task.GeneratedIconPath.ItemSpec;
+				Assert.EndsWith(".ico", generatedIcon, StringComparison.OrdinalIgnoreCase);
+				Assert.True(File.Exists(generatedIcon), $"Expected generated icon to exist: {generatedIcon}");
+
+				var expectedSizes = new[] { 16, 24, 32, 48, 64, 128, 256 };
+				var actualSizes = new HashSet<int>();
+
+				using var stream = File.OpenRead(generatedIcon);
+				using var reader = new BinaryReader(stream);
+				Assert.Equal((short)0x0000, reader.ReadInt16());
+				Assert.Equal((short)0x0001, reader.ReadInt16());
+
+				var imageCount = reader.ReadInt16();
+				Assert.Equal(expectedSizes.Length, imageCount);
+
+				for (var i = 0; i < imageCount; i++)
+				{
+					var width = reader.ReadByte();
+					var height = reader.ReadByte();
+					reader.ReadByte(); // color palette size
+					reader.ReadByte(); // reserved
+					reader.ReadInt16(); // color planes
+					reader.ReadInt16(); // bits per pixel
+					reader.ReadInt32(); // data size
+					reader.ReadInt32(); // offset
+
+					var normalizedSize = width == 0 ? 256 : width;
+					Assert.Equal(normalizedSize, height == 0 ? 256 : height);
+					actualSizes.Add(normalizedSize);
+				}
+
+				Assert.Equal(expectedSizes.OrderBy(size => size), actualSizes.OrderBy(size => size));
+			}
+
+			[Fact]
 			public void SingleImageWithOnlyPathSucceeds()
 			{
 				var items = new[]


### PR DESCRIPTION
Fixes: #374

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Currently the generated .ico only has 64x64 size image. Which is rendered blurry and doesn't scale in Explorer thumbnail.

## What is the new behavior?
The icon contains all necessary sizes from 16x16 upto 256x256. Which will render appropriately in Windows Explorer.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)