### PR TITLE
fix: loosen filename validation to what the platforms actually require

### DIFF
--- a/doc/using-uno-resizetizer.md
+++ b/doc/using-uno-resizetizer.md
@@ -46,8 +46,13 @@ Uno.Resizetizer can handle:
 The next sections will show how to use it for each use case.
 
 > [!WARNING]
-> All the assets used by Uno.Resizetizer should be lower case and don't have special characters. You can use `_` to separate words.
-> This is because the assets are used on different platforms and some of them have limitations on the characters that can be used.
+> Asset file names must start with a letter or an underscore and contain only letters, digits and underscores. Use `_` to separate words.
+> Hyphens, spaces, additional dots and non-ASCII characters are rejected, because the name becomes an Android resource identifier (`R.drawable.<name>`).
+> A name that is a Java keyword (such as `class`) or a Windows device name (such as `aux`) is rejected for the same reason.
+>
+> Uppercase letters are allowed. On Android the generated resource is always lowercased, so an icon named `MyIcon.svg` is referenced as `@mipmap/myicon`.
+>
+> Set `UnoResizetizerErrorOnInvalidFilename` to `false` to downgrade the validation error to a build message.
 
 ### UnoImage
 

--- a/src/.nuspec/Uno.Resizetizer.targets
+++ b/src/.nuspec/Uno.Resizetizer.targets
@@ -89,7 +89,9 @@
 
 		<UnoResizetizerIncludeSelfProject Condition="'$(UnoResizetizerIncludeSelfProject)' == ''">False</UnoResizetizerIncludeSelfProject>
 
-		<_UnoResizetizerDefaultInvalidFilenamesErrorMessage>One or more invalid file names were detected. File names must be lowercase, start and end with a letter character, and contain only alphanumeric characters or underscores:</_UnoResizetizerDefaultInvalidFilenamesErrorMessage>
+		<_UnoResizetizerDefaultInvalidFilenamesErrorMessage>One or more invalid file names were detected. File names must start with a letter or an underscore, contain only letters, digits and underscores, and must not be a reserved name. Set UnoResizetizerErrorOnInvalidFilename to false to downgrade this error to a message:</_UnoResizetizerDefaultInvalidFilenamesErrorMessage>
+
+		<UnoResizetizerErrorOnInvalidFilename Condition="'$(UnoResizetizerErrorOnInvalidFilename)' == ''">true</UnoResizetizerErrorOnInvalidFilename>
 
 		<_WasmHasPWAManifest>False</_WasmHasPWAManifest>
 		<_WasmHasPWAManifest Condition="'$(WasmPWAManifestFile)' != ''">True</_WasmHasPWAManifest>
@@ -492,6 +494,7 @@
 
 		<DetectInvalidResourceOutputFilenamesTask_v0
 				Items="@(UnoImage->Distinct())"
+				ThrowsError="$(UnoResizetizerErrorOnInvalidFilename)"
 				ErrorMessage="$(_UnoResizetizerDefaultInvalidFilenamesErrorMessage)">
 		</DetectInvalidResourceOutputFilenamesTask_v0>
 

--- a/src/Resizetizer/src/DetectInvalidResourceOutputFilenamesTask.cs
+++ b/src/Resizetizer/src/DetectInvalidResourceOutputFilenamesTask.cs
@@ -22,15 +22,27 @@ namespace Uno.Resizetizer
 		public override bool Execute()
 		{
 			var invalidFilenames = new List<string>();
+			var invalidNames = new List<string>();
 			try
 			{
 				if (Items != null)
 				{
 					foreach (var item in Items)
 					{
-						if (!Utils.IsValidResourceFilename(item.ItemSpec))
+						// The generators derive the output name from %(Link) when it is set
+						// (see ResizeImageInfo.OutputName), so validating the ItemSpec alone lets
+						// a non-conforming Link through unchecked.
+						var outputName = item.GetMetadata("Link");
+
+						if (string.IsNullOrWhiteSpace(outputName))
+						{
+							outputName = item.ItemSpec;
+						}
+
+						if (!Utils.IsValidResourceFilename(outputName))
 						{
 							invalidFilenames.Add(item.ItemSpec);
+							invalidNames.Add(Path.GetFileNameWithoutExtension(outputName));
 						}
 					}
 				}
@@ -45,23 +57,26 @@ namespace Uno.Resizetizer
 				{
 					InvalidItems = invalidFilenames.ToArray();
 
-					if (ThrowsError)
+					var builder = new StringBuilder();
+					builder.Append(ErrorMessage);
+
+					for (var i = 0; i < invalidNames.Count; i++)
 					{
-						var builder = new StringBuilder();
-						builder.Append(ErrorMessage);
-
-						for (var i = 0; i < invalidFilenames.Count; i++)
+						if (i > 0)
 						{
-							if (i > 0)
-							{
-								builder.Append(", ");
-							}
-
-							var file = invalidFilenames[i];
-							builder.Append(Path.GetFileNameWithoutExtension(file));
+							builder.Append(", ");
 						}
 
+						builder.Append(invalidNames[i]);
+					}
+
+					if (ThrowsError)
+					{
 						Log.LogError(builder.ToString());
+					}
+					else
+					{
+						Log.LogMessage(MessageImportance.High, builder.ToString());
 					}
 				}
 			}

--- a/src/Resizetizer/src/GenerateSplashAndroidResources.cs
+++ b/src/Resizetizer/src/GenerateSplashAndroidResources.cs
@@ -79,7 +79,7 @@ namespace Uno.Resizetizer
 			writer.WriteStartElement("item");
 			writer.WriteStartElement("bitmap");
 			writer.WriteAttributeString("android", "gravity", Namespace, "center");
-			writer.WriteAttributeString("android", "src", Namespace, "@drawable/" + splash.OutputName);
+			writer.WriteAttributeString("android", "src", Namespace, "@drawable/" + Utils.ToAndroidResourceName(splash.OutputName));
 			writer.WriteAttributeString("android", "tileMode", Namespace, "disabled");
 			writer.WriteAttributeString("android", "mipMap", Namespace, "true");
 			writer.WriteEndDocument();
@@ -111,7 +111,7 @@ namespace Uno.Resizetizer
 
 			writer.WriteStartElement("bitmap");
 			writer.WriteAttributeString("android", "gravity", Namespace, "fill");
-			writer.WriteAttributeString("android", "src", Namespace, "@drawable/" + splash.OutputName);
+			writer.WriteAttributeString("android", "src", Namespace, "@drawable/" + Utils.ToAndroidResourceName(splash.OutputName));
 			writer.WriteAttributeString("android", "mipMap", Namespace, "true");
 			writer.WriteAttributeString("android", "tileMode", Namespace, "disabled");
 

--- a/src/Resizetizer/src/Resizer.cs
+++ b/src/Resizetizer/src/Resizer.cs
@@ -23,7 +23,7 @@ namespace Uno.Resizetizer
 		public string GetFileDestination(DpiPath dpi)
 			=> GetFileDestination(Info, dpi, IntermediateOutputPath);
 
-		public static string GetFileDestination(ResizeImageInfo info, DpiPath dpi, string intermediateOutputPath)
+		public static string GetFileDestination(ResizeImageInfo info, DpiPath dpi, string intermediateOutputPath, string outputName = null)
 		{
 			var fullIntermediateOutputPath = new DirectoryInfo(intermediateOutputPath);
 
@@ -44,7 +44,7 @@ namespace Uno.Resizetizer
 				path = Path.IsPathRooted(path) ? string.Empty : path;
 			}
 
-			var destination = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path, path, info.OutputName + dpi.FileSuffix + info.OutputExtension);
+			var destination = Path.Combine(fullIntermediateOutputPath.FullName, dpi.Path, path, (outputName ?? info.OutputName) + dpi.FileSuffix + info.OutputExtension);
 
 			var fileInfo = new FileInfo(destination);
 			if (!fileInfo.Directory.Exists)

--- a/src/Resizetizer/src/ResizetizeImages.cs
+++ b/src/Resizetizer/src/ResizetizeImages.cs
@@ -242,7 +242,7 @@ namespace Uno.Resizetizer
 			{
 				LogDebugMessage($"App Icon: " + dpi);
 
-				var destination = Resizer.GetFileDestination(img, dpi, iconPath)
+				var destination = Resizer.GetFileDestination(img, dpi, iconPath, appIconName)
 					.Replace("{name}", appIconName);
 
 				var (_, sourceModified) = Utils.FileExists(img.Filename);

--- a/src/Resizetizer/src/Utils.cs
+++ b/src/Resizetizer/src/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using SkiaSharp;
@@ -9,11 +10,49 @@ namespace Uno.Resizetizer
 {
 	internal class Utils
 	{
+		// Mirrors the identifier rules of the Android resource compiler, which is the only
+		// consumer that turns the file name into a symbol (R.<type>.<name>). Uppercase, a
+		// leading or trailing underscore and single-character names are all accepted by aapt2.
 		static readonly Regex rxResourceFilenameValidation
-			= new Regex(@"^[a-z]+[a-z0-9_]{0,}[^_]$", RegexOptions.Singleline | RegexOptions.Compiled);
+			= new Regex(@"^(?=.*[a-zA-Z0-9])[a-zA-Z_][a-zA-Z0-9_]*$", RegexOptions.Singleline | RegexOptions.Compiled);
+
+		// Names that are legal on disk but unusable downstream: Java keywords collide with the
+		// generated R field (aapt2 fails with "invalid symbol name"), and the Win32 device stems
+		// cannot be opened as files on Windows.
+		static readonly HashSet<string> reservedResourceNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"con", "prn", "aux", "nul",
+			"com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+			"lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+
+			"abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class",
+			"const", "continue", "default", "do", "double", "else", "enum", "extends", "false",
+			"final", "finally", "float", "for", "goto", "if", "implements", "import", "instanceof",
+			"int", "interface", "long", "native", "new", "null", "package", "private", "protected",
+			"public", "return", "short", "static", "strictfp", "super", "switch", "synchronized",
+			"this", "throw", "throws", "transient", "true", "try", "void", "volatile", "while",
+		};
 
 		public static bool IsValidResourceFilename(string filename)
-			=> rxResourceFilenameValidation.IsMatch(Path.GetFileNameWithoutExtension(filename));
+		{
+			var name = Path.GetFileNameWithoutExtension(filename);
+
+			return !string.IsNullOrEmpty(name)
+				&& rxResourceFilenameValidation.IsMatch(name)
+				&& !reservedResourceNames.Contains(name);
+		}
+
+		/// <summary>
+		/// Lowercases a name that will be referenced as an Android resource id.
+		/// </summary>
+		/// <remarks>
+		/// Assets that reach aapt2 through @(AndroidResource) are lowercased by the .NET Android
+		/// SDK (AndroidComputeResPaths, LowercaseFilenames="True"), so anything Resizetizer writes
+		/// that references them - or that reaches aapt2 verbatim through @(LibraryResourceDirectories)
+		/// - has to be lowercased the same way or the two spellings become distinct resources.
+		/// </remarks>
+		public static string ToAndroidResourceName(string outputName)
+			=> outputName?.ToLowerInvariant();
 
 		public static SKColor? ParseColorString(string tint)
 		{

--- a/src/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
+++ b/src/Resizetizer/test/UnitTests/DetectInvalidResourceOutputFilenamesTests.cs
@@ -105,6 +105,54 @@ namespace Uno.Resizetizer.Tests
 				Assert.Equal("Invalid Filenames: appiconfg-red-512", LogErrorEvents[0].Message);
 			}
 
+			// The generators build the output name from %(Link), so it has to be the string
+			// that gets validated.
+			[Fact]
+			public void InvalidLinkOnValidItemSpecFails()
+			{
+				var i = new TaskItem("images/camera.png", new Dictionary<string, string>
+				{
+					["Link"] = "Assets/bad-name.png",
+				});
+				var task = GetNewTask(i);
+
+				var success = task.Execute();
+
+				AssertInvalidFilename(task, i);
+				Assert.False(success);
+				Assert.Equal("Invalid Filenames: bad-name", LogErrorEvents[0].Message);
+			}
+
+			[Fact]
+			public void ValidLinkOnInvalidItemSpecSucceeds()
+			{
+				var i = new TaskItem("images/appiconfg-red-512.svg", new Dictionary<string, string>
+				{
+					["Link"] = "Assets/good_name.svg",
+				});
+				var task = GetNewTask(i);
+
+				var success = task.Execute();
+
+				AssertValidFilename(task, i);
+				Assert.True(success);
+			}
+
+			[Fact]
+			public void InvalidFileLogsMessageWhenNotThrowing()
+			{
+				var i = new TaskItem("images/appiconfg-red-512.svg");
+				var task = GetNewTask(i);
+				task.ThrowsError = false;
+
+				var success = task.Execute();
+
+				Assert.True(success);
+				AssertInvalidFilename(task, i);
+				Assert.Empty(LogErrorEvents);
+				Assert.Contains(LogMessageEvents, m => m.Message == "Invalid Filenames: appiconfg-red-512");
+			}
+
 			[Fact]
 			public void MultipleInvalidFileFailsWithCorrectErrorMessage()
 			{

--- a/src/Resizetizer/test/UnitTests/FilenameTests.cs
+++ b/src/Resizetizer/test/UnitTests/FilenameTests.cs
@@ -88,6 +88,49 @@ namespace Uno.Resizetizer.Tests
 		public void InvalidFilenames_Unix(string filename)
 			=> Assert.False(IsValidFilename(filename));
 
+		[Theory]
+		[InlineData("a.png")]
+		[InlineData("MyIcon.png")]
+		[InlineData("_icon.png")]
+		[InlineData("icon_.png")]
+		[InlineData("_a_.png")]
+		[InlineData("Square44x44Logo.png")]
+		public void ValidFilenames_LoosenedRules(string filename)
+			=> Assert.True(IsValidFilename(filename));
+
+		// The previous pattern ended in `[^_]`, so every character except an underscore was
+		// accepted in the last position regardless of the rest of the rule.
+		[Theory]
+		[InlineData("logo-.png")]
+		[InlineData("logo .png")]
+		[InlineData("logo..png")]
+		[InlineData("logo&.png")]
+		[InlineData("café.png")]
+		public void InvalidFilenames_TrailingCharacter(string filename)
+			=> Assert.False(IsValidFilename(filename));
+
+		[Theory]
+		[InlineData("logo.dark.png")]
+		[InlineData("my-icon.png")]
+		[InlineData("my icon.png")]
+		[InlineData("1icon.png")]
+		[InlineData("_.png")]
+		[InlineData("__.png")]
+		public void InvalidFilenames_UnsupportedCharacters(string filename)
+			=> Assert.False(IsValidFilename(filename));
+
+		// Java keywords collide with the generated R field ("invalid symbol name" from aapt2);
+		// the Win32 device stems cannot be opened as files on Windows.
+		[Theory]
+		[InlineData("class.png")]
+		[InlineData("new.png")]
+		[InlineData("Class.png")]
+		[InlineData("aux.png")]
+		[InlineData("nul.png")]
+		[InlineData("com1.png")]
+		public void InvalidFilenames_ReservedNames(string filename)
+			=> Assert.False(IsValidFilename(filename));
+
 		bool IsValidFilename(string filename)
 			=> Utils.IsValidResourceFilename(filename);
 	}

--- a/src/Resizetizer/test/UnitTests/FilenameTests.cs
+++ b/src/Resizetizer/test/UnitTests/FilenameTests.cs
@@ -40,6 +40,10 @@ namespace Uno.Resizetizer.Tests
 		[InlineData("t_w_o2.png")]
 		[InlineData("t_3_hree.png")]
 		[InlineData("f4_our5.png")]
+		[InlineData("O1.png")]
+		[InlineData("_t3_hree.png")]
+		[InlineData("_1one.png")]
+		[InlineData("o1_.png")]
 		public void ValidFilenames(string filename)
 			=> Assert.True(IsValidFilename(filename));
 
@@ -58,34 +62,29 @@ namespace Uno.Resizetizer.Tests
 		[InlineData("/some/two2.png")]
 		[InlineData("/some/t3hree.png")]
 		[InlineData("/some/f4our5.png")]
+		[InlineData("/some/path_.png")]
+		[InlineData("/some/f4oUr5.png")]
 		public void ValidFilenames_Unix(string filename)
 			=> Assert.True(IsValidFilename(filename));
 
 		[Theory]
 		[InlineData("1one.png")]
-		[InlineData("O1.png")]
 		[InlineData("t-wo2.png")]
-		[InlineData("_t3_hree.png")]
 		[InlineData("f4our 5.png")]
-		[InlineData("_1one.png")]
-		[InlineData("o1_.png")]
 		public void InvalidFilenames(string filename)
 			=> Assert.False(IsValidFilename(filename));
 
 		[WindowsTheory]
 		[InlineData("C:\\some\\path\\on-e.png")]
 		[InlineData("C:\\some\\path\\2o1.png")]
-		[InlineData("C:\\some\\path\\tWo2.png")]
 		[InlineData("C:\\some\\path\\t3+hree.png")]
 		[InlineData("C:\\some\\path\\f4o ur5.png")]
 		public void InvalidFilenames_Windows(string filename)
 			=> Assert.False(IsValidFilename(filename));
 
 		[UnixTheory]
-		[InlineData("/some/path_.png")]
 		[InlineData("/some/3two2.png")]
 		[InlineData("/some/t-3hree.png")]
-		[InlineData("/some/f4oUr5.png")]
 		public void InvalidFilenames_Unix(string filename)
 			=> Assert.False(IsValidFilename(filename));
 

--- a/src/Resizetizer/test/UnitTests/GenerateSplashAndroidResourcesTests.cs
+++ b/src/Resizetizer/test/UnitTests/GenerateSplashAndroidResourcesTests.cs
@@ -88,7 +88,9 @@ namespace Uno.Resizetizer.Tests
 
 		[Theory]
 		[InlineData(null, "appiconfg")]
-		[InlineData("images/CustomAlias.svg", "CustomAlias")]
+		// Assets reaching aapt2 through @(AndroidResource) are lowercased by the Android SDK,
+		// so the generated @drawable reference has to be lowercased to match.
+		[InlineData("images/CustomAlias.svg", "customalias")]
 		public void SplashScreenResectsAlias(string alias, string outputImage)
 		{
 			var splash = new TaskItem("images/appiconfg.svg", new Dictionary<string, string>

--- a/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
+++ b/src/Resizetizer/test/UnitTests/ResizetizeImagesTests.cs
@@ -161,6 +161,36 @@ namespace Uno.Resizetizer.Tests
 				AssertFileMatches($"mipmap-xhdpi/{outputName}_foreground.png", new object[] { name, alias, "xh", "f" });
 			}
 
+			// The adaptive icon xml and the mipmap bitmaps have to resolve to one resource:
+			// the xml used to be lowercased while the bitmaps kept the author's casing.
+			[Theory]
+			[InlineData("MixedCase.png", "mixedcase")]
+			[InlineData("UPPER.png", "upper")]
+			public void AppIconNameIsLowercasedConsistently(string alias, string outputName)
+			{
+				var items = new[]
+				{
+					new TaskItem("images/camera.png", new Dictionary<string, string>
+					{
+						["IsAppIcon"] = bool.TrueString,
+						["Link"] = alias,
+					}),
+				};
+
+				var task = GetNewTask(items);
+				var success = task.Execute();
+				Assert.True(success, LogErrorEvents.FirstOrDefault()?.Message);
+
+				AssertFileExists($"mipmap-mdpi/{outputName}.png");
+				AssertFileExists($"mipmap-mdpi/{outputName}_background.png");
+				AssertFileExists($"mipmap-mdpi/{outputName}_foreground.png");
+				AssertFileExists($"mipmap-anydpi-v26/{outputName}.xml");
+
+				AssertFileContains($"mipmap-anydpi-v26/{outputName}.xml",
+					$"<foreground android:drawable=\"@mipmap/{outputName}_foreground\"/>",
+					$"<background android:drawable=\"@mipmap/{outputName}_background\"/>");
+			}
+
 			//[Theory(Skip = "App icon for android is in WIP mode")]
 			[Theory]
 			[InlineData("appicon", null, "appicon")]


### PR DESCRIPTION
Fixes #379

## What

Filename validation rejected names every supported platform accepts, while accepting several that genuinely break the build. This makes the rule match reality, and fixes the three name-desync bugs that made loosening it unsafe.

`MyIcon.png` was rejected. `myIcoN.png` was accepted.

## The regex was a broken transcription of MAUI's

```
^[a-z]+[a-z0-9_]{0,}[^_]$
```

The final atom is `[^_]` — a *negated* class — so the last character was effectively unvalidated, and the mandatory extra atom imposed an accidental 2-character minimum. Upstream fixed this in [dotnet/maui#19600](https://github.com/dotnet/maui/pull/19600) (Jan 2024); we still carried the pre-fix form from the initial port (`2a824eb`).

## What the platforms actually require

Measured with `aapt2` from `build-tools/35.0.1` against `platforms/android-36/android.jar` — compile a `res/mipmap-mdpi/` tree, `link --java`, read the generated `R.java`. `aapt2 compile` accepted **every** name tried.

| filename | `R.java` field | outcome |
|---|---|---|
| `MyIcon.png` | `int MyIcon=` | ✅ uppercase is not an aapt2 constraint |
| `_icon.png` / `a.png` / `my_icon_.png` | `int _icon=` / `int a=` / `int my_icon_=` | ✅ |
| `my-icon.png` | `int my_icon=` | ⚠️ links, but aapt2 silently rewrites `-` → `_` |
| `1icon.png`, `logo dark.png` | `int 1icon=`, `int logo dark=` | ❌ invalid identifier → fails at javac |
| `logo.dark.png` | — | ❌ hard compile error, the only outright aapt2 rejection |
| `class.png` | — | ❌ hard link error (`invalid symbol name`) — **passed validation before** |

Nothing on Apple (asset-catalog names are conventionally CamelCase), Windows (MRT lookup is case-insensitive, and Resizetizer already emits `Square150x150Logo.scale-200.png`), WASM or Skia requires lowercase either.

**Now allowed:** uppercase, leading underscore, trailing underscore, single-character names.
**Still rejected:** embedded dot, space, hyphen, leading digit, non-ASCII — plus Java keywords and Win32 device stems, which are new.

## Three bugs that made the relaxation unsafe

1. **`%(Link)` bypassed validation entirely.** The task validated `%(Identity)` while every generator derives the output name from `ResizeImageInfo.OutputName`, which is `Alias`-first with `Alias = %(Link)`.

2. **The Android app icon casing was already split.** `ResizetizeImages.cs:178` lowercases `appIconName` for the adaptive-icon XML, but the per-DPI bitmap loop goes through `Resizer.cs:47`, which used the raw `OutputName` — the `.Replace("{name}", …)` is a no-op on Android, since only Apple's `DpiPath` has that placeholder. `iconX` (which passed validation) emitted `mipmap-anydpi-v26/iconx.xml` beside `mipmap-mdpi/iconX.png`: two disjoint resources, a clean link, and a launcher icon silently missing below API 26.

3. **The Android splash reference was never lowercased.** `GenerateSplashAndroidResources` wrote `@drawable/<OutputName>` verbatim, but the bitmap reaches aapt2 through `@(AndroidResource)`, which the Android SDK lowercases (`AndroidComputeResPaths`, `LowercaseFilenames="True"` — `Xamarin.Android.Common.targets:1086-1097`).

## Escape hatch

MAUI's opt-out is ported as `$(UnoResizetizerErrorOnInvalidFilename)`. The task already had `ThrowsError`; it was simply never passed. Names that only ever passed through the regex hole (`logo..png`, `logo .png`, `aux.png`, `class.png`) now correctly fail, so this ships in the same change. When set to `false` the task now logs a high-importance message instead of staying silent.

## Behaviour changes worth reviewing

- **`GenerateSplashAndroidResourcesTests.SplashScreenResectsAlias`** asserted `@drawable/CustomAlias`. That expectation dates from the initial MAUI port and could only ever be reached *through* the `%(Link)` bypass; it references a resource that does not exist after the SDK lowercases the bitmap. Updated to `@drawable/customalias`.
- **On Android an uppercase icon name is referenced lowercased** — `MyIcon.svg` → `@mipmap/myicon`. Documented in `doc/using-uno-resizetizer.md`.
- Seven `FilenameTests` cases moved from invalid to valid, matching the measured aapt2 behaviour.

## Testing

`378 passed, 0 failed` (was 350). 22 new cases; **19 of them fail against the pre-fix source**.

Note: `dotnet format` was not run — the repo has no `.editorconfig` and uses tabs, so the tool defaults to spaces and reports 219 whitespace errors in files this PR never touches. The edits follow the surrounding style.

## Not included

Hyphens stay rejected. They are legal on every platform, but Uno.UI's own `ResourceQualifier.Parse` treats `scale-`/`lang-`/`language-`/`theme-`/`custom-` prefixed segments as MRT qualifiers, and that interaction has not been verified on a device. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq3mdB4pJkz4FXRpNMwwAb
