### PR TITLE
ci: Publish from servicing/* branches and bump main to 2.0-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,23 @@
 name: CI
 
+# A servicing/* branch continues a previous version line after main has moved on
+# to a newer one, so it builds, signs and publishes dev packages the same way main
+# does. The same pattern is added to the CI triggers, the sign and publish_dev jobs
+# and version.json's publicReleaseRefSpec. It deliberately does NOT reach the
+# publish_release_* jobs, which stay behind the Stable approval gate.
+
 on: 
   push:
     branches:
       - main
+      - servicing/**
       - release/*/*
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
+      - servicing/**
       - release/*/*
 
 env:
@@ -244,7 +252,7 @@ jobs:
 
   sign:
     name: Sign
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/servicing/') || startsWith(github.ref, 'refs/heads/release/')) }}
     runs-on: windows-latest
     environment: PackageSign
 
@@ -306,7 +314,7 @@ jobs:
  # Publish dev packages to uno feed and nuget.org
   publish_dev:
     name: Publish Dev
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/servicing/')) }}
     runs-on: ubuntu-latest
     needs: sign
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - servicing/*
       - release/* 
 
 env:

--- a/version.json
+++ b/version.json
@@ -6,6 +6,7 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.13-dev.{height}",
+  "version": "2.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` is this repo's dev line: it carries `1.13-dev.{height}` and `publish_dev` pushes `1.13.0-dev.*` to the Uno feed and nuget.org on every merge, ungated. It is the **only** branch publishing a Resizetizer dev channel.

`release/stable/X.Y` is the production line, and both of its publish jobs — `publish_release_uno` and `publish_release_nuget_org` — run under `environment: Stable`, which has required reviewers. That is right for a stable release, but it means a `release/*` branch cannot carry a dev channel: every dev build would need an approval.

`servicing/*` is not wired into this workflow at all, so cutting such a branch today produces a branch that builds nothing.

## What is the new behavior?

Two commits, and they land together.

### 1. `ci: Publish dev packages from servicing/* branches`

`servicing/*` gets the same build → sign → `publish_dev` path `main` uses, and nothing else:

| Change | Why |
|---|---|
| `servicing/**` in `push.branches` and `pull_request.branches` | CI runs on the branch at all, and on PRs into it |
| `servicing/` in the `sign` job condition | packages are signed as on `main`. `environment: PackageSign` has no protection rules or branch policy, so no gate is introduced |
| `servicing/` in the `publish_dev` job condition | the ungated dev publish to the Uno feed **and** nuget.org runs, matching `main` |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` | NBGV emits `1.13.0-dev.N` rather than a height-plus-commit-hash version |
| `servicing/*` in `.github/workflows/conventional-commits.yml` | `main`'s branch protection will be mirrored onto the servicing branch, so this check must report for PRs into it — otherwise those PRs sit forever on a check that never runs |

`publish_release_uno` and `publish_release_nuget_org` keep their `startsWith(refs/heads/release/)` conditions. Servicing must not reach the `Stable` gate — that is the whole reason it is a separate branch pattern. This mirrors what `unoplatform/uno.templates` carries for its `servicing/6.8` branch.

### 2. `chore: Bump version to 2.0-dev for the Uno 7.0 line`

`main` moves to `2.0-dev.{height}`; `servicing/1.13` is then cut from **this PR's first commit** and keeps publishing `1.13.0-dev.*` for apps on Uno 6.x.

A major rather than a minor because the 2.0 line targets the Uno Platform 7.0 era, which drops Mac Catalyst — and Mac Catalyst DPI paths are still carried in `Uno.Resizetizer.apple.targets`, `Uno.Resizetizer.targets` and `DpiPath.cs`. Removing them is a breaking change for anyone still targeting that platform, so they stay served by `1.13.x`. It also keeps this repo consistent with the rest of the 7.0 programme, where every split repo signalled the era with a major.

### Why the bump is not optional

`main`'s latest published version is `1.13.0-dev.17`. A `servicing/1.13` branch cut from `main` computes the **same** NBGV heights, so both branches would publish an identical `1.13.0-dev.N` from different code — and the duplicate push is skipped **silently, on a green build**. One branch's packages would simply never appear.

Moving `main` to `2.0-dev` separates the version spaces. Verified with `nbgv`:

| Commit | Version | Height |
|---|---|---|
| `10f3cb3` (ci plumbing) | `1.13` | 18 |
| `ac41568` (version bump) | `2.0` | 1 |

So `servicing/1.13`, cut at `10f3cb3`, resumes at `1.13.0-dev.18` — a number `main` never publishes, because it restarts at `2.0.0-dev.1`. No `versionHeightOffset` needed.

## PR Checklist

- [x] Associated with an issue (internal — Uno 7.0 release preparation)

## Other information

Follow-ups after this merges: cut `servicing/1.13` at `10f3cb3` and mirror `main`'s branch protection onto it (`Build` + `Validation Check`, 1 approving review, conversation resolution required).

Unrelated and still outstanding on this repo: the 6.7 SR2 alignment needs the "don't fail on disabled PWA" fix backported to `release/stable/1.12` so a stable `1.12.2` exists — the shipped `Uno.Sdk 6.7.22` currently pins the prerelease `1.13.0-dev.17`.
